### PR TITLE
Unnecessary table element rule

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,8 +75,6 @@ input, select { vertical-align:middle; }
 */
 body { font:13px/1.231 sans-serif; *font-size:small; } /* hack retained to preserve specificity */
 
-table { font-size:inherit; font: 100% sans-serif; }
-
 select, input, textarea, button { font:99% sans-serif; }
 
 /* normalize monospace sizing 


### PR DESCRIPTION
A very minor thing... This `font: 100%;` declaration on the table element is missing the required font-family value (the declaration is ignored without it).  On second look, I think the entire rule can be removed. `font-size: 100%` and `font-size: inherit` achieve the same effect (afaik) and the table element is already is set to `font-size: 100%` in the reset. =)
