### PR TITLE
Removing IE's Gallery Image Toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
   <!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame 
        Remove this if you use the .htaccess -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-
+  
+  <!-- Disable IE6 image and print toolbar -->
+  <meta http-equiv="imagetoolbar" content="no">
+ 
   <title></title>
   <meta name="description" content="">
   <meta name="author" content="">


### PR DESCRIPTION
Gallery Image Toolbar places a toolbar over an image if hovered, the meta tag disables that behavior. 
more info at http://davidwalsh.name/remove-internet-explorers-gallery-image-toolbar
