### PR TITLE
Using AddOutputFilterByType instead of incorrect(?) AddOutputFilter to compress output

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -90,8 +90,8 @@ AddType text/x-component              htc
 <IfModule mod_deflate.c>
 
 # html, txt, css, js, json, xml, htc:
-  AddOutputFilter DEFLATE text/html text/plain text/css text/javascript application/javascript application/json 
-  AddOutputFilter DEFLATE text/xml application/xml text/x-component
+  AddOutputFilterByType DEFLATE text/html text/plain text/css text/javascript application/javascript application/json
+  AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
 
 # webfonts and svg:
   <FilesMatch "\.(ttf|otf|eot|svg)$" >


### PR DESCRIPTION
I tried incorporating the `.htaccess` into a project but noticed that the responses weren't getting gzipped. However, once I changed `AddOutputFilter` to `AddOutputFilterByType` it worked fine. 
