### PR TITLE
Fix favicon display in IE when using apache

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -20,8 +20,6 @@
 # Because X-UA-Compatible isn't sent to non-IE (to save header bytes),
 #   We need to inform proxies that content changes based on UA
   Header append Vary User-Agent
-# Ensure proxy caching, since gzip is accept-encoding dependent.
-  Header append Vary Accept-Encoding
 # Cache control is set only if mod_headers is enabled, so that's unncessary to declare
 </IfModule>
 


### PR DESCRIPTION
Hi,

Here is a very minor change that allow favicon to be displayed correctly in IE when you use Apache.
Moreover, Accept encoding header is automatically added by mod_deflate (cf. http://httpd.apache.org/docs/2.2/mod/mod_deflate.html#proxies)

Thx,
Yann
