### PR TITLE
Using appropriate directive to send compressed output

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -106,9 +106,20 @@ AddType application/octet-stream       safariextz
 <IfModule mod_deflate.c>
 
 # html, txt, css, js, json, xml, htc:
+<IfModule mod_filter.c>
+  FilterDeclare COMPRESS
+  FilterProvider COMPRESS DEFLATE resp=Content-Type $\btext/(html|plain|css|javascript|xml|x-component)\b
+  FilterProvider COMPRESS DEFLATE resp=Content-Type $\bapplication/(javascript|json|xml|x-javascript)\b
+  FilterChain COMPRESS
+  FilterProtocol COMPRESS change=yes;byteranges=no
+</IfModule>
+
+<IfModule !mod_filter.c>
+  # Legacy versions of Apache
   AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
   AddOutputFilterByType DEFLATE text/javascript application/javascript application/x-javascript 
   AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
+</IfModule>
 
 # webfonts and svg:
   <FilesMatch "\.(ttf|otf|eot|svg)$" >


### PR DESCRIPTION
Commented out AddOutputFilterByType with instructions asking to uncomment for legacy version.
Using Filter module instead of AddOutputFilter as instructed by Apache documentation.
More info: http://github.com/paulirish/html5-boilerplate/commit/7db47878f80366597d19f0a5b0e6df55275fa51f#commitcomment-158644
