### PR TITLE
Crossdomain.xml policy file

### DIFF
--- a/crossdomain.xml
+++ b/crossdomain.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0"?>
-<!DOCTYPE cross-domain-policy SYSTEM "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd">
+<!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!--
-        If you host a crossdomain.xml file with allow-access-from domain=“*” 
-        and don’t understand all of the points described here, you probably 
-        have a nasty security vulnerability. ~ simon willison 
-        
-        Please read: www.adobe.com/devnet/flashplayer/articles/cross_domain_policy.html
-    
-   <allow-access-from domain="*" to-ports="*" />
-   
-   -->
+<!-- README: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+<!-- Most restrictive policy: -->
+	<site-control permitted-cross-domain-policies="none"/>
+<!-- Least restrictive policy: -->
+<!--
+	<site-control permitted-cross-domain-policies="all"/>
+	<allow-access-from domain="*" to-ports="*" secure="false"/>
+	<allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+-->
 </cross-domain-policy>
-
-


### PR DESCRIPTION
Updated the crossdomain.xml policy file so the most restrictive policy is set as the default, with an option to have a more liberal policy file (commented out). The doctype has been updated to point to Adobe rather than Macromedia, and it now includes a link to the most recent documentation from Adobe.
