### PR TITLE
Add lighttpd config file

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -1,0 +1,143 @@
+############ Options you really have to take care of ####################
+
+## Run as an unpriveleged user
+server.username            = "www"
+server.groupname           = "www"
+
+## to help the rc.scripts
+server.pid-file            = "/var/run/lighttpd/lighttpd.pid"
+
+## A static document-root. For virtual hosting take a look at the
+## mod_simple_vhost module.
+server.document-root        = "/var/www/sites/go/here/"
+
+## modules to load
+# at least mod_access and mod_accesslog should be loaded
+server.modules              = (
+	"mod_access",
+	"mod_accesslog", 
+	"mod_redirect",
+	"mod_compress",
+	"mod_expire"
+)
+
+### File uploads
+# Make sure this folder exists and is writable to server.username
+server.upload-dirs        = ( "/tmp/lighttpd/uploads" )
+
+## where to send error-messages to
+server.errorlog             = "/var/log/lighttpd/error.log"
+
+#### accesslog module
+accesslog.filename          = "/var/log/lighttpd/access.log"
+
+### compress module
+# Make sure this folder exists and is writable to server.username
+compress.cache-dir         = "/tmp/lighttpd/compress/"
+compress.filetype          = ( 
+	"text/plain", 
+	"text/html", 
+	"text/css", 
+	"application/json",
+	"text/javascript", 
+	"application/javascript", 
+	"application/x-javascript", 
+	"text/xml", 
+	"application/xml", 
+	"application/xml-rss", 
+	"text/x-component",
+)
+
+# files to check for if .../ is requested
+index-file.names            = ( 
+	"index.html",
+	"index.htm",
+)
+
+## set the event-handler (read the performance section in the manual)
+# server.event-handler = "freebsd-kqueue" # needed on OS X
+
+# mimetype mapping
+mimetype.assign             = (
+  ".pdf"          =>      "application/pdf",
+  ".sig"          =>      "application/pgp-signature",
+  ".spl"          =>      "application/futuresplash",
+  ".class"        =>      "application/octet-stream",
+  ".ps"           =>      "application/postscript",
+  ".torrent"      =>      "application/x-bittorrent",
+  ".dvi"          =>      "application/x-dvi",
+  ".gz"           =>      "application/x-gzip",
+  ".pac"          =>      "application/x-ns-proxy-autoconfig",
+  ".swf"          =>      "application/x-shockwave-flash",
+  ".tar.gz"       =>      "application/x-tgz",
+  ".tgz"          =>      "application/x-tgz",
+  ".tar"          =>      "application/x-tar",
+  ".zip"          =>      "application/zip",
+  ".mp3"          =>      "audio/mpeg",
+  ".m3u"          =>      "audio/x-mpegurl",
+  ".wma"          =>      "audio/x-ms-wma",
+  ".wax"          =>      "audio/x-ms-wax",
+  ".ogg"          =>      "application/ogg",
+  ".wav"          =>      "audio/x-wav",
+  ".gif"          =>      "image/gif",
+  ".jar"          =>      "application/x-java-archive",
+  ".jpg"          =>      "image/jpeg",
+  ".jpeg"         =>      "image/jpeg",
+  ".png"          =>      "image/png",
+  ".xbm"          =>      "image/x-xbitmap",
+  ".xpm"          =>      "image/x-xpixmap",
+  ".xwd"          =>      "image/x-xwindowdump",
+  ".css"          =>      "text/css",
+  ".html"         =>      "text/html",
+  ".htm"          =>      "text/html",
+  ".js"           =>      "text/javascript",
+  ".json"         =>      "text/javascript",
+  ".asc"          =>      "text/plain",
+  ".c"            =>      "text/plain",
+  ".cpp"          =>      "text/plain",
+  ".log"          =>      "text/plain",
+  ".conf"         =>      "text/plain",
+  ".text"         =>      "text/plain",
+  ".txt"          =>      "text/plain",
+  ".dtd"          =>      "text/xml",
+  ".xml"          =>      "text/xml",
+  ".mpeg"         =>      "video/mpeg",
+  ".mpg"          =>      "video/mpeg",
+  ".mov"          =>      "video/quicktime",
+  ".qt"           =>      "video/quicktime",
+  ".avi"          =>      "video/x-msvideo",
+  ".asf"          =>      "video/x-ms-asf",
+  ".asx"          =>      "video/x-ms-asf",
+  ".wmv"          =>      "video/x-ms-wmv",
+  ".bz2"          =>      "application/x-bzip",
+  ".tbz"          =>      "application/x-bzip-compressed-tar",
+  ".tar.bz2"      =>      "application/x-bzip-compressed-tar",
+  # default mime type
+  ""              =>      "application/octet-stream",
+ )
+
+## deny access the file-extensions
+#
+# ~    is for backupfiles from vi, emacs, joe, ...
+# .inc is often used for code includes which should in general not be part
+#      of the document-root
+url.access-deny             = ( "~", ".inc" )
+
+$HTTP["url"] =~ "\.pdf$" {
+  server.range-requests = "disable"
+}
+
+##
+# which extensions should not be handle via static-file transfer
+#
+# .php, .pl, .fcgi are most often handled by mod_fastcgi or mod_cgi
+static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
+
+## bind to all ips, or change to a specific ip
+server.bind                = "0.0.0.0"
+
+# If its an asset, expires in a month from now
+expire.url                  = (
+	"\.(ico|ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|css|rss|atom|js|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf)" => "access plus 10 years", 
+	".*" => "access plus 1 month"
+)


### PR DESCRIPTION
If only to point out the absense of a config file for lighttpd (given theres one for apache, nginx, and iis - seems reasonable). Here's a start point at a config file with comparable functionality to that of the nginx and apache conf files.

It's likely to need reviewing :)

Regards,

AD
