### PR TITLE
Added nginx MIME type additions

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -43,8 +43,11 @@
 </FilesMatch>
 
 
+#audio
+AddType audio/ogg                      oga ogg
+
 # video
-AddType video/ogg                      ogg ogv
+AddType video/ogg                      ogv
 AddType video/mp4                      mp4
 AddType video/webm                     webm
 

--- a/mime.types
+++ b/mime.types
@@ -59,11 +59,11 @@ types {
     audio/midi                            mid midi kar;
     audio/mpeg                            mp3;
     audio/x-realaudio                     ra;
-    audio/ogg                             oga;
+    audio/ogg                             oga ogg;
 
     video/3gpp                            3gpp 3gp;
     video/mpeg                            mpeg mpg;
-    video/ogg                             ogg ogv;
+    video/ogg                             ogv;
     video/quicktime                       mov;
     video/webm                            webm;
     video/x-flv                           flv;


### PR DESCRIPTION
As I noted in the commit message, the default MIME types nginx ships with are missing several important types. I know Firefox in particular is picky when it comes to audio/video MIME types (which nginx does not come with).

I've included all of the MIME type additions in the Apache .htaccess file that already exists. However, the file I've added is named `mime.types` which seems rather generic. Should a `conf` directory at the root be created to contain all server-related configuration files?
