### PR TITLE
Small print style enhancement: Show only existing info

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,8 +270,8 @@ button {  width: auto; overflow: visible; }
 @media print {
   * { background: transparent !important; color: #444 !important; text-shadow: none !important; }
   a, a:visited { color: #444 !important; text-decoration: underline; }
-  a:after { content: " (" attr(href) ")"; } 
-  abbr:after { content: " (" attr(title) ")"; }
+  a[href]:after { content: " (" attr(href) ")"; }
+  abbr[title]:after { content: " (" attr(title) ")"; }
   .ir a:after { content: ""; }  /* Don't show links for images */
   pre, blockquote { border: 1px solid #999; page-break-inside: avoid; }
   thead { display: table-header-group; } /* css-discuss.incutio.com/wiki/Printing_Tables */ 


### PR DESCRIPTION
There are (rare) cases, where `a` and `abbr` occur without `@href` and `@title`, respectively. In these cases don't print a meaningless `()`.

The fix doesn't prevent empty `@href` or `@title`, though.
