### PR TITLE
exclude config files from being copied to publish folder

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -71,6 +71,8 @@
         <exclude name="**/.git/**"/>
         <exclude name="**/.svn/**"/>
         <exclude name=".gitignore"/>
+        <exclude name="*.conf*"/>
+        <exclude name="mime.types"/>
         <exclude name="**/${dir.build}/**"/>
         <exclude name="**/${dir.test}/**"/>
         <exclude name="**/${dir.demo}/**"/>


### PR DESCRIPTION
I'm not sure about web.config, but the other config files shouldn't be copied to what is going to be a public location. Even though the config files should be the first thing to experience the true delete-friendly nature of html5-boilerplate, its better to err on the side of caution and prevent any left over config files from polluting the result of the build.
