### PR TITLE
Use 'append' instead of 'set' for the cache-control: public header

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -121,7 +121,6 @@ AddType application/octet-stream       safariextz
 #   "access plus 1 week" or so
 
 <IfModule mod_expires.c>
-  Header set Cache-Control "public"
   ExpiresActive on
 
 # Perhaps better to whitelist expires rules? Perhaps.
@@ -166,6 +165,8 @@ AddType application/octet-stream       safariextz
   ExpiresByType text/css                  "access plus 1 month"
   ExpiresByType application/javascript    "access plus 1 month"
   ExpiresByType text/javascript           "access plus 1 month"
+
+  Header append Cache-Control "public"
 </IfModule>
 
 


### PR DESCRIPTION
Apache was overwriting the cache-control: public header set on line 124 of .htaccess with all the ExpiresByType directives.  By moving it down and using 'append' instead of 'set', the max-age is preserved.

(Thanks for a great project, BTW.  Nice to have everything clean and in one place when starting work.)

Cheers from Vancouver Island, Canada,

Alex
