### PR TITLE
Alternative way to target all IEs at once in HTML-tag hack.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!doctype html>  
 
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ --> 
-<!--[if lt IE 7 ]> <html lang="en" class="no-js ie6"> <![endif]-->
-<!--[if IE 7 ]>    <html lang="en" class="no-js ie7"> <![endif]-->
-<!--[if IE 8 ]>    <html lang="en" class="no-js ie8"> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+<!--[if lt IE 7 ]> <html lang="en" class="no-js ie ie6"> <![endif]-->
+<!--[if IE 7 ]>    <html lang="en" class="no-js ie ie7"> <![endif]-->
+<!--[if IE 8 ]>    <html lang="en" class="no-js ie ie8"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="no-js no-ie"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
 


### PR DESCRIPTION
I'm defining an ".ie" class for all IEs 6 to 8, and a ".no-ie" (Modernizr-style) for everything else. This goes along with the existing .ie6/.ie7/.ie8 classes, but targets all an once. I found this very useful to avoid repetition in my CSS files.
