### PR TITLE
dreamweaver files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 nbproject
 thumbs.db
 
+# Dreamweaver added files
+_notes
+dwsync.xml
+
 # Folders to ignore
 .hg
 .svn


### PR DESCRIPTION
Added exclude rules for files added by dreamweaver to .gitignore
