### PR TITLE
Ensure that .htaccess works even if mod_headers is not installed

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -180,7 +180,9 @@ AddType application/octet-stream       safariextz
   ExpiresByType application/javascript    "access plus 1 month"
   ExpiresByType text/javascript           "access plus 1 month"
 
-  Header append Cache-Control "public"
+  <IfModule mod_headers.c>
+    Header append Cache-Control "public"
+  </IfModule>
 </IfModule>
 
 


### PR DESCRIPTION
.htaccess currently has one "Header" statement that's not wrapped with an < IfModule mod_headers.c >

Have added that in this pull request.

Regards
Anand
