### PR TITLE
Protection against leaving console statements in your app

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -48,7 +48,7 @@
 (function(doc){
   var write = doc.write;
   doc.write = function(q){ 
-    log('document.write(): ',arguments); 
+    console.log('document.write(): ',arguments); 
     if (/docwriteregexwhitelist/.test(q)) write.apply(doc,arguments);  
   };
 })(document);


### PR DESCRIPTION
I really like Paul's `window.log()` because it's super lightweight. However, I want to use the other awesome methods console provides. Also, I wasn't excited about how Webkit displays log messages when you pass it the `arguments` object. The native `console.log()` display is nicer, especially when you're logging arrays because the `arguments` object/quasi-array is already displayed a bit like an array.

Also, I think developers are used to using `console` methods and ultimately, what they want (at least what I want), is protection against leaving one stupid `console.log()` or `console.warn()` in your app and all of a sudden breaking everything.

So, I came up with the shortest syntax I could think of for making sure a `console` object exists and making sure any missing methods are replaced with a no-op function.

I've seen Ben Alman's solution that I think you worked with him on, Paul. There's also [Clientcide's dbug](http://www.clientcide.com/docs). Again, I like those, but they both have the same issue with formatting in webkit — and I still feel they're a tad bit big for a "leave-in" solution.

Anyway, thanks for HTML5 Boilerplate — lots of good stuff here.

Hope you like my little patch, see ya on the twitter webz. I'm [@HenrikJoreteg](http://twitter.com/HenrikJoreteg)
