### PR TITLE
Make jpegtran work on linux

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -308,9 +308,10 @@
             only do so if you own copyright to the image -->
       <arg value="all"/>
       <srcfile/>
-      <targetfile/>
       <!-- you may want to flag optimized images. If so, do it here. Otherwise change this to type="identity" -->
-      <mapper type="glob" from="*.jpg" to="../${dir.publish}/${dir.images}/*.jpg"/>
+      <redirector>
+          <outputmapper type="glob" from="*.jpg" to="./${dir.publish}/${dir.images}/*.jpg"/>
+      </redirector>
     </apply>
     <apply executable="jpegtran" osfamily="mac">
       <fileset dir="./${dir.publish}/${dir.images}/" includes="*.jpg"/>


### PR DESCRIPTION
Hello,

jpegtran on ubuntu 10.10 (but other unixes also from what I can understand) doesn't take the output file as a command line argument. It outputs the content of the resulting file. Therefore, the build.xml has to be changed very lightly to work correctly.

Hope you are interested,

Laurent
