### PR TITLE
Some improvements to the asynchronous Google Analytics snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,10 +78,10 @@
 
   <!-- mathiasbynens.be/notes/async-analytics-snippet Change UA-XXXXX-X to be your site's ID -->
   <script>
-    var_gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
-    (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=true;
-    g.src=('https:'==location.protocol?'https://ssl':'http://www')+'.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g,s)})(document,'script');
+    var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
+    (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
+    g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+    s.parentNode.insertBefore(g,s)}(document,'script'));
   </script>
   
 </body>


### PR DESCRIPTION
I think there was a small typo in commit e4183675f144a654b955f2a90776c7f83c9a2143 (missing space after `var`). I fixed that, optimized the protocol check, and replaced `async=true` with `async=1`.
