### PR TITLE
RequestHeaders requires that mod_headers is loaded

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -134,10 +134,11 @@ AddType application/octet-stream       safariextz
 
 # force deflate for mangled headers developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/
 <IfModule mod_setenvif.c>
-  SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s,?\s(gzip|deflate)?|X{4,13}|~{4,13}|-{4,13})$ HAVE_Accept-Encoding
-  RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+  <IfModule mod_headers.c>
+    SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s,?\s(gzip|deflate)?|X{4,13}|~{4,13}|-{4,13})$ HAVE_Accept-Encoding
+    RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+  </IfModule>
 </IfModule>
-
 # html, txt, css, js, json, xml, htc:
 <IfModule filter_module>
   FilterDeclare   COMPRESS


### PR DESCRIPTION
Wrapped the mangled header detection in a mod_headers.c <IfModule>
