### PR TITLE
Proper mime-type for WOFF fonts (also in Chrome)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -91,8 +91,7 @@ AddEncoding gzip                       svgz
 AddType application/vnd.ms-fontobject  eot
 AddType font/truetype                  ttf
 AddType font/opentype                  otf
-AddType font/opentype                  woff
-        # ^ hack to avoid chrome console warning: crbug.com/70283
+AddType application/x-font-woff              woff
 
 # assorted types                                      
 AddType image/x-icon                   ico


### PR DESCRIPTION
Use application/x-font-woff as the current mime-type, as the IETF review has not been approved yet.
Chrome Canary doesn't show the warning anymore.
