### PR TITLE
Use mod_rewrite to always add or remove a trailing slash

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -342,7 +342,7 @@ FileETag None
 <IfModule mod_rewrite.c>
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_URI} !(\.[a-zA-Z0-9]{1,5}|/|#(.*))$
-  RewriteRule ^(.*[^/])$ /$1/ [R=301,L]
+  RewriteRule ^(.*)$ /$1/ [R=301,L]
 </IfModule>
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Google will treat `http://example.com/foo` and `http://example.com/foo/` _separately_ (but equally).

Google recommends having one of those URLs do a 301 redirect to the other. I think most people decide to add the trailing slash, so that's what I've activated by default, but options are in place for always-adding or always-removing.

http://googlewebmastercentral.blogspot.com/2010/04/to-slash-or-not-to-slash.html  

http://www.alistapart.com/articles/slashforward/  
