### PR TITLE
IE hr element alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,7 @@ abbr[title], dfn[title] { border-bottom:1px dotted; cursor:help; }
 
 table { border-collapse:collapse; border-spacing:0; }
 
-hr { display:block; height:1px; border:0; border-top:1px solid #ccc; margin:1em 0; padding:0; }
+hr { display:block; height:1px; border:0; border-top:1px solid #ccc; margin:1em 0; padding:0; text-align:left;}
 
 input, select { vertical-align:middle; }
 


### PR DESCRIPTION
Test Case: http://www.hixie.ch/tests/evil/mixed/hrbrstyles.html

Edit the second example (in webkit for example), set inline style: margin: 1em 0 (like in the boilerplate css), now give it a width of 100px. It will align left.

If you do the same thing in IE(7,8, yet to test IE6) it will align center, because it uses text-align internally rather than margin (as should be according to the HTML5 spec) . Adding text-align: left fixes this.

---

http://www.w3.org/TR/html5/rendering.html#the-hr-element-0
