### PR TITLE
Bugfix for build.xml to add version number to css files

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -563,7 +563,7 @@
 
 	
 	<!-- CSS -->
-	<target name="-css" description="Concatenates and Minifies any stylesheets listed in the file.stylesheets property">
+	<target name="-css" depends="-load-build-info" description="Concatenates and Minifies any stylesheets listed in the file.stylesheets property">
 		<echo message="Minifying css..."/>
 		
 		<concat destfile="./${dir.publish}/${dir.css}/style-${build.number}.css">


### PR DESCRIPTION
build.xml doesn't currently add version numbers to the built css files:
    $ cd build/
    $ ant minify
    Buildfile: build.xml

```
minify:
     [echo] Building a Production Environment...

...

BUILD SUCCESSFUL
Total time: 7 seconds

$ ll ../publish/css/
total 40K
drwxr-xr-x 2 chris chris 4.0K 2011-02-12 19:04 .
drwxr-xr-x 5 chris chris 4.0K 2011-02-12 19:04 ..
-rw-r--r-- 1 chris chris  238 2011-02-12 19:04 handheld.css
-rw-r--r-- 1 chris chris 8.1K 2011-02-12 19:04 style-${build.number}.css
-rw-r--r-- 1 chris chris 3.6K 2011-02-12 19:04 style-${build.number}.min.css
-rw-r--r-- 1 chris chris 8.1K 2011-02-12 19:04 style.css
```

After adding `depends="-load-build-info"` to line 566 in build.xml
    $ cd build/
    $ ant minify
    Buildfile: build.xml

```
minify:
     [echo] Building a Production Environment...

...

BUILD SUCCESSFUL
Total time: 7 seconds

$ ll ../publish/css/
total 40K
drwxr-xr-x 2 chris chris 4.0K 2011-02-12 19:05 .
drwxr-xr-x 5 chris chris 4.0K 2011-02-12 19:05 ..
-rw-r--r-- 1 chris chris  238 2011-02-12 19:05 handheld.css
-rw-r--r-- 1 chris chris 8.1K 2011-02-12 19:05 style-0002.css
-rw-r--r-- 1 chris chris 3.6K 2011-02-12 19:05 style-0002.min.css
-rw-r--r-- 1 chris chris 8.1K 2011-02-12 19:05 style.css
```
