### PR TITLE
Allow configuration of 'source' directory in build

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -403,7 +403,7 @@
 		<var name="excluded-files" value="${file.default.exclude}, ${file.exclude}"/>
 
 		<copy todir="./${dir.publish}">
-			<fileset dir="./" excludes="${excluded-files}"/>
+			<fileset dir="${dir.source}/" excludes="${excluded-files}"/>
 		</copy>	
 	</target>
 	

--- a/build/config/default.properties
+++ b/build/config/default.properties
@@ -8,6 +8,7 @@
 #
 # Directory Paths
 #
+dir.source                                      = .
 dir.publish					= publish
 dir.build						= build
 dir.build.tools			= ${dir.build}/tools


### PR DESCRIPTION
I had a need to not have the build script assume that the parent directory is the root of everything.  For example, in a Django app, it is fairly typical to have a directory structure so:

```
/
/static
/templates
/code with py files
```

I wanted to use boilerplate to optimize all my JS and CSS in /static, and also optimize my single base template.  But I didn't want /build to live in /static as that just ends up being served by nginx in the end.  So I added a new variable to the default.properties: "dir.source", which defaults to the parent directory of /build, but can be set to something different.  With that set to "static", I can have the following config:

```
/ 
/static
/templates
/optimized_static (my dir.publish)
/build
```

And just use a symlink to switch between using /static or /optimized_static, usually using static during development.

It's a teeny change that makes my life easier and doesn't affect the default case on iota.  Hope you can fold it in.
