### PR TITLE
Fix ie9 filter stupidity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,6 +144,10 @@ button {  width: auto; overflow: visible; }
    code.flickr.com/blog/2008/11/12/on-ui-quality-the-little-things-client-side-image-resizing/ */
 .ie7 img { -ms-interpolation-mode: bicubic; }
 
+/* Stop IE9 from obliterating rounded corners when -ms-filter was used for gradients in IE lte 8 (use SVG instead):
+   http://dl.dropbox.com/u/105727/web/toesteppin/index.html */
+.ie9 * { filter: none !important; -ms-filter: none !important; }
+
 /**
  * You might tweak these..
  */

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <!--[if lt IE 7 ]> <html class="no-js ie6" lang="en"> <![endif]-->
 <!--[if IE 7 ]>    <html class="no-js ie7" lang="en"> <![endif]-->
 <!--[if IE 8 ]>    <html class="no-js ie8" lang="en"> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<!--[if IE 9 ]>    <html class="no-js ie9" lang="en"> <![endif]-->
+<!--[if (gte IE 10)|!(IE)]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
 


### PR DESCRIPTION
If you browse to
http://dl.dropbox.com/u/105727/web/toesteppin/index.html
in IE9, you will notice the two boxes look a bit different: One has rounded corners, and the other doesn’t; both should, but since IE9 is honoring the archaic `-ms-filter` gradients defined for old versions of IE, it draws the gradient "over" the rounded corners; this would happen in both boxes with gradients, but for that `-ms-filter: none !important` was applied to the second, preserving the `border-radius`.

If this is unclear, I could write a longer explanation, perhaps as a blog post.
