### PR TITLE
Fixes a bug with android 2.2 & 2.3 browser that causes @media max-device-width queries to fail.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta name="author" content="">
 
   <!-- Mobile viewport optimized: j.mp/bplateviewport -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, target-densitydpi=device-dpi, initial-scale=1.0">
 
   <!-- Place favicon.ico & apple-touch-icon.png in the root of your domain and delete these references -->
   <link rel="shortcut icon" href="/favicon.ico">


### PR DESCRIPTION
Fixes a bug with android 2.2 & 2.3 browser that causes @media max-device-width queries to fail randomly.

The inclusion of target-densitydpi=device-dpi in the <meta name="viewport"> tag fixes this.
