### PR TITLE
HTML5 input placeholder color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -154,7 +154,15 @@ body, select, input, textarea {
   /* Set your base font here, to apply evenly */
   /* font-family: Georgia, serif;  */
 }
-
+/* Default dark gray color for HTML5 input placeholder text.
+   Opera also supports the placeholder attribute, but currently not styling:
+   stackoverflow.com/questions/2610497/change-an-inputs-html5-placeholder-color-with-css/2610741#2610741 */
+input::-webkit-input-placeholder {
+    color: #A9A9A9;
+}
+input:-moz-placeholder {
+    color: #A9A9A9;
+}
 /* Headers (h1, h2, etc) have no default font-size or margin; define those yourself */
 h1, h2, h3, h4, h5, h6 { font-weight: bold; }
 


### PR DESCRIPTION
Felt a default input placeholder color should be added — WebKit defaults to darkGray (or #A9A9A9). Added a link to discussion on stackoverflow on how to style the attribute (has to be separate rules). Seems Opera currently doesn't support styling, and I'm unsure about IE9 (looked around MSDN, but couldn't find anything).
