### PR TITLE
Fix createproject.sh directory copying

### DIFF
--- a/build/createproject.sh
+++ b/build/createproject.sh
@@ -34,7 +34,7 @@ else
     echo "Created Directory: $dst"
     
     cd "$src"
-    cp -vr css/ js/ img/ *.html *.xml *.txt *.png *.ico .htaccess "$dst"
+    cp -vr css js img *.html *.xml *.txt *.png *.ico .htaccess "$dst"
 
     #sucess message
     echo "Created Project: $dst"


### PR DESCRIPTION
Small fix that prevents copying contents of "css", "js" and "img" folders into the project root, copy into the directories with the same names instead.
