### PR TITLE
Facebook Share Icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,12 @@
   <link rel="shortcut icon" href="/favicon.ico">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     
-  <!-- Uncomment to provide icon for when facebook users share a link to the site. Must be absolute url. -->
-  <!-- <link rel="image_src" href="http://yourawesomesite.com/facebook-share-icon.png" />  -->
+  <!-- Facebook will use the following data to represent your site when it is shared.
+       Facebook documentation (includes info on sharing more specific
+       media types): http://developers.facebook.com/docs/share -->
+    <meta property="og:title" content="" />
+    <meta property="og:description" content="" />
+    <meta property="og:image" content="" />
 
   <!-- CSS: implied media="all" -->
   <link rel="stylesheet" href="css/style.css?v=2">


### PR DESCRIPTION
In the index.html head, I added a meta tag for facebook users who share links. The image specified in the tag becomes the thumbnail on the facebook post. For the share icon, I duplicated the 114x114 apple touch icon.
