### PR TITLE
fix proposal for issue #397

### DIFF
--- a/build/createproject.sh
+++ b/build/createproject.sh
@@ -13,7 +13,15 @@
 # $ ./createproject.sh
 
 # find project root (also ensure script is ran from within repo)
-src=$(git rev-parse --show-toplevel) || exit 1
+src=$(git rev-parse --show-toplevel) || {
+  echo "try running the script from within html5-boilerplate directories." >&2
+  exit 1
+}
+[[ -d $src ]] || {
+  echo "fatal: could not determine html5-boilerplate's root directory." >&2
+  echo "try updating git." >&2
+  exit 1
+}
 
 # get a name for new project
 while [[ -z $name ]]


### PR DESCRIPTION
fix proposal for issue #397
- verifies that the output of `git rev-parse` is a directory
- protects commands against weird filenames
