### PR TITLE
Fix Changelog's v1.0 release date typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Changelog:
 
-### v.1.0 : March 21st, 2010
+### v.1.0 : March 21st, 2011
 
 #### Build Script
 <ul>


### PR DESCRIPTION
v1.0 was released on March 21st, **2011**
