### PR TITLE
Disable directory browsing by default

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -443,7 +443,7 @@ AddCharset utf-8 .html .css .js .xml .json .rss
 # "-Indexes" will have Apache block users from browsing folders without a default document
 # Usually you should leave this activated, because you shouldn't allow everybody to surf through
 # every folder on your server (which includes rather private places like CMS system folders).
-# Options -Indexes
+Options -Indexes
 
 
 # Block access to "hidden" directories whose names begin with a period. This


### PR DESCRIPTION
It's usually a bad idea to enable directory browsing. I suggest disabling it by default.
