### PR TITLE
Edited style.css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -114,7 +114,7 @@ input[type="checkbox"] { vertical-align: bottom; }
 .ie6 input { vertical-align: text-bottom; }
 
 /* Hand cursor on clickable input elements */
-label, input[type="button"], input[type="submit"], input[type="image"], button { cursor: pointer; }
+label[for], input[type="button"], input[type="submit"], input[type="image"], button { cursor: pointer; }
 
 /* Webkit browsers add a 2px margin outside the chrome of form elements */
 button, input, select, textarea { margin: 0; }


### PR DESCRIPTION
Labels are only clickable when they have a valid 'for' attribute so the selector has been updated to reflect this. This fails when you have a radio button inside a label element without a for but it's a better trade off then making a potentially misleading assumption.
