### PR TITLE
Input and button fixes for IE + Firefox. Slight reorganisation of related rules

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -118,7 +118,7 @@ input[type="checkbox"] { vertical-align: bottom; }
 .ie6 input { vertical-align: text-bottom; }
 
 /* Hand cursor on clickable input elements */
-label, input[type="button"], input[type="submit"], input[type="image"], button { cursor: pointer; }
+input[type="button"], input[type="submit"], input[type="image"], button { cursor: pointer; }
 
 /* 1) Make inputs and buttons play nice in IE: www.viget.com/inspire/styling-the-button-element-in-internet-explorer/
    2) WebKit browsers add a 2px margin outside the chrome of form elements. 


### PR DESCRIPTION
This jsfiddle shows that `input` needs the IE fix, and that Firefox (on Windows at least) has extra padding - http://jsfiddle.net/jAZ5t/

I reorganised the CSS file to group similar rulesets together and merge some fixes into fewer rulesets. The place I've moved the link styles might not be the best. Might be better in the 'tweak' area actually.

Edited for brevity.
