### PR TITLE
Updating TTF mimetype to fix Google Chrome warning

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -89,7 +89,7 @@ AddEncoding gzip                       svgz
                                        
 # webfonts                             
 AddType application/vnd.ms-fontobject  eot
-AddType application/x-font-truetype    ttf ttc
+AddType application/x-font-ttf    ttf ttc
 AddType font/opentype                  otf
 AddType application/x-font-woff        woff
 


### PR DESCRIPTION
Google Chrome throws a warning on TTF files. This mime type update fixes it.
