### PR TITLE
Added common class for long text wrap (whitespace)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -213,10 +213,10 @@ h1, h2, h3, h4, h5, h6 { font-weight: bold; }
 /* Fix clearfix: blueprintcss.lighthouseapp.com/projects/15318/tickets/5-extra-margin-padding-bottom-of-page */
 .clearfix { zoom: 1; }
 
-/* Forces a word wrap */
+/* Forces a word wrap (extended version) - https://developer.mozilla.org/en/CSS/white-space*/
 .wordwrap{
 	white-space: pre-wrap; /* CSS3 */
-	white-space: -moz-pre-wrap; /* Mozilla */
+	white-space: -moz-pre-wrap; /* Firefox 1-2 */
 	white-space: -pre-wrap; /* Opera 4-6 */
 	white-space: -o-pre-wrap; /* Opera 7 */
 	word-wrap: break-word; /* IE 5.5+ */


### PR DESCRIPTION
I've used this for quite a while in various places; its a version of the example stated here https://developer.mozilla.org/en/CSS/white-space with extra to handle older versions of Opera (these could probably be dropped ~ does anyone really care about opera).
