### PR TITLE
DNS Prefetching

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
 <head>
   <meta charset="utf-8">
 
+  <!-- DNS Prefetching: Add dns-prefetch links for all of your CDNs
+       http://dev.chromium.org/developers/design-documents/dns-prefetching
+       https://developer.mozilla.org/En/Controlling_DNS_prefetching 
+  <link rel="dns-prefetch" href="//image.cdn.url.example.com">
+  -->
+  
   <!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame
        Remove this if you use the .htaccess -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
I always forget to add the urls of my image CDNs for DNS-Prefetch, so I added it to my boilerplate fork.  Maybe use for for others too?

If you pull this in I'll update the html5-boilerplate wiki with information on when to use dns-prefetching.
