### PR TITLE
Allow blackberry to read vcards

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -101,6 +101,7 @@ AddType text/x-component               htc
 AddType application/x-chrome-extension crx
 AddType application/x-xpinstall        xpi
 AddType application/octet-stream       safariextz
+AddType text/x-vcard                   vcf
 
 
 


### PR DESCRIPTION
Blackberries can't add contact from a .vcf vCard if it isn't served with the correct MIME Type.

I'm sorry, but my English is too poor.
