### PR TITLE
Unify cursor across IE for elements inside anchor (<a>)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,12 +105,12 @@ pre {
   padding: 15px;
 }
 
-.ie6 legend, .ie7 legend { margin-left: -7px; } 
+.ie6 legend, .ie7 legend { margin-left: -7px; }
 
 /* 1) Make inputs and buttons play nice in IE: www.viget.com/inspire/styling-the-button-element-in-internet-explorer/
-   2) WebKit browsers add a 2px margin outside the chrome of form elements. 
-      Firefox adds a 1px margin above and below textareas 
-   3) Set font-size to match <body>'s, and font-family to sans-serif 
+   2) WebKit browsers add a 2px margin outside the chrome of form elements.
+      Firefox adds a 1px margin above and below textareas
+   3) Set font-size to match <body>'s, and font-family to sans-serif
    4) Align to baseline */
 button, input, select, textarea { width: auto; overflow: visible; margin: 0; font-size: 100%; font-family: sans-serif; vertical-align: baseline; }
 
@@ -120,6 +120,9 @@ textarea { overflow: auto; vertical-align:text-top; }
 
 /* Hand cursor on clickable input elements */
 label, input[type="button"], input[type="submit"], input[type="image"], button { cursor: pointer; }
+
+/* Hand cursor on elements inside anchor */
+.ie6 a *, .ie7 a *, .ie8 a * { cursor: pointer; }
 
 /* Remove extra padding and inner border in Firefox */
 input::-moz-focus-inner,
@@ -158,7 +161,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: bold; }
 /**
  * Primary styles
  *
- * Author: 
+ * Author:
  */
 
 


### PR DESCRIPTION
Sometimes Internet Explorer refuses to show the pointer (hand) cursor when hovering elements (like span elements) that are actually insde an anchor element (a).

All other browsers does it so I add this line of code for every project that I have. I hope it's useful.

I've added it for IE6-8. May be it is required even for latest versions. I haven't tested that much.
