### PR TITLE
Robust touch icon support for Android devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,16 +18,11 @@
   <!-- Mobile viewport optimized: j.mp/bplateviewport -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <!-- Maximum compatability with Android devices, remove this block if Android support is not necessary
-       http://mathiasbynens.be/notes/touch-icons#sizes -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="apple-touch-icon-114x114-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="apple-touch-icon-72x72-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" href="apple-touch-icon-precomposed.png">
-
+  <!-- For proper iOS touch icon support, ensure favicon.ico and apple-touch-icon.png
+       are placed in the root directory: Mathias Bynens http://goo.gl/6nVq0 -->
 
   <!-- CSS: implied media="all" -->
   <link rel="stylesheet" href="css/style.css">
-
 
   <!-- All JavaScript at the bottom, except for Modernizr which enables HTML5 elements & feature detects -->
   <script src="js/libs/modernizr-1.7.min.js"></script>


### PR DESCRIPTION
If I'm understanding Mathias' post correctly (http://mathiasbynens.be/notes/touch-icons#sizes), the best way to implement proper touch icon support for the widest variety of devices would be through this snippet.

```
<link rel="apple-touch-icon-precomposed" sizes="114x114" href="apple-touch-icon-114x114-precomposed.png">
<link rel="apple-touch-icon-precomposed" sizes="72x72" href="apple-touch-icon-72x72-precomposed.png">
<link rel="apple-touch-icon-precomposed" href="apple-touch-icon-precomposed.png">
```

Those for whom Android support matters to can keep the snippet in, whereas others can simply delete the entire block and go the no-html route.

I apologize if this has already been discussed, and decided against.
