### PR TITLE
log() arguments are no longer wrapped in extraneous array

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -7,9 +7,9 @@ window.log = function(){
   if(this.console) {
     arguments.callee = arguments.callee.caller;
     if(typeof console.log === 'object'){
-        Function.prototype.apply.call(console.log, console, Array.prototype.slice.call(arguments))
+      Function.prototype.apply.call(console.log, console, Array.prototype.slice.call(arguments))
     } else {
-        console.log.apply(console, Array.prototype.slice.call(arguments));
+      console.log.apply(console, Array.prototype.slice.call(arguments));
     }
   }
 };


### PR DESCRIPTION
I found the extra array to be confusing, so I removed it.

Previously:

```
> log('what');
["what"]
> log(['what']);
[["what"]]
```

Now:

```
> log('what');
"what"
> log(['what']);
["what"]
```

In IE9 the output is different, but not different than what console.log would give you anyway.

This probably isn't a big deal for most people, but maybe it helps clarify output when using Web Inspector/Firebug. The if statement is to deal with IE's console.log, since it's an object and not a function. I've tested in FF4, IE9, IE8, IE7, Chrome 11.
