### PR TITLE
Moved GA above other scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,13 +50,6 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
   <script>window.jQuery || document.write("<script src='js/libs/jquery-1.6.1.min.js'>\x3C/script>")</script>
 
-
-  <!-- scripts concatenated and minified via ant build script-->
-  <script src="js/plugins.js"></script>
-  <script src="js/script.js"></script>
-  <!-- end scripts-->
-
-	
   <!-- mathiasbynens.be/notes/async-analytics-snippet Change UA-XXXXX-X to be your site's ID -->
   <script>
     var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"],["_trackPageLoadTime"]];
@@ -64,6 +57,11 @@
     g.src=("https:"==location.protocol?"//ssl":"//www")+".google-analytics.com/ga.js";
     s.parentNode.insertBefore(g,s)}(document,"script"));
   </script>
+
+  <!-- scripts concatenated and minified via ant build script-->
+  <script src="js/plugins.js"></script>
+  <script src="js/script.js"></script>
+  <!-- end scripts-->
 
 </body>
 </html>


### PR DESCRIPTION
Moved the GA snippet above the rest of the JS, so that the _gaq var is declared and can be accessed in the other scripts.

We are using Mathias' snippet of `var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"],["_trackPageLoadTime"]];` instead of google's default `var _gaq = _gaq || [];`

Therefore I think we should place the variable declaration before the other scripts. Otherwise we can't track page views and events from the scripts.
