### PR TITLE
added Header unset ETag 

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -33,6 +33,9 @@
 </IfModule>
 
 <IfModule mod_headers.c>
+# FileETag None is not enough for every server.
+  Header unset ETag
+
 # Because X-UA-Compatible isn't sent to non-IE (to save header bytes),
 #   We need to inform proxies that content changes based on UA
   Header append Vary User-Agent


### PR DESCRIPTION
In some servers setting "FileETag None" alone, is not enough. Removing header and setting it to None fixes the issue.
