### PR TITLE
Valid CSS definition for body font-size 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -58,7 +58,9 @@ hr { display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin:
  * Font normalization inspired by YUI Library's fonts.css: developer.yahoo.com/yui/
  */
 
-body { font:13px/1.231 sans-serif; *font-size:small; } /* Hack retained to preserve specificity */
+body { font:13px/1.231 sans-serif; }
+/* Font normalization is needed for IE6 and IE7 */
+.ie6 body, .ie7 body { font-size: small; }
 
 /* Normalize monospace sizing:
    en.wikipedia.org/wiki/MediaWiki_talk:Common.css/Archive_11#Teletype_style_fix_for_Chrome */


### PR DESCRIPTION
star hack applies to only IE6 & IE7.
See example http://centricle.com/ref/css/filters/tests/asterisk/

Also, it is not a valid CSS definition. 
