### PR TITLE
Fix .ir fringe case failure when <br>s are used in the .ir text.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -181,6 +181,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: bold; }
 
 /* For image replacement */
 .ir { display: block; text-indent: -999em; overflow: hidden; background-repeat: no-repeat; text-align: left; direction: ltr; }
+.ir br { display: none; }
 
 /* Hide for both screenreaders and browsers:
    css-discuss.incutio.com/wiki/Screenreader_Visibility */


### PR DESCRIPTION
Hard breaks in image-replaced text negate the negative text indent. This fix causes line breaks in image-replaced text not to be displayed, fixing the effect.
