### PR TITLE
.ir text-indent in px marginally safer?

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -180,7 +180,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: bold; }
  */
 
 /* For image replacement */
-.ir { display: block; text-indent: -999em; overflow: hidden; background-repeat: no-repeat; text-align: left; direction: ltr; }
+.ir { display: block; text-indent: -32000px; overflow: hidden; background-repeat: no-repeat; text-align: left; direction: ltr; }
 
 /* Hide for both screenreaders and browsers:
    css-discuss.incutio.com/wiki/Screenreader_Visibility */


### PR DESCRIPTION
Changed text-indent value from em to px. This addresses a couple of potential issues:
- Setting a font-size of 0 on an .ir element will cause the text not to be indented. In browsers that have a minimum font size, this causes the text to be shown -- not an expected behavior.
- Setting a large font size on an element can cause a maximum threshold to be crossed in Opera 8, which supports a maximum text-indent value of 32697px (see http://natek.typepad.com/blog/2005/07/opera_8_max_val.html). Kind of an obscure edge case, but why not avoid it?

I'm pretty sure this approach is marginally safer than using em. Anything I'm missing here?
