### PR TITLE
Added additional mp4 extensions to MIME types

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -76,10 +76,11 @@
 
 # audio
 AddType audio/ogg                      oga ogg
+AddType audio/mp4                      m4a
 
 # video
 AddType video/ogg                      ogv
-AddType video/mp4                      mp4
+AddType video/mp4                      mp4 m4v
 AddType video/webm                     webm
 
 # Proper svg serving. Required for svg webfonts on iPad


### PR DESCRIPTION
I needed m4a to get an m4a to play in IE9. HandBrake's default mp4 extension is m4v. Not sure if anything fails without it, but added it to be complete.
