### PR TITLE
Modify apache mod_deflate .htaccess triggers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -133,7 +133,6 @@ AddType text/x-vcard                   vcf
 
 <IfModule mod_deflate.c>
 
-
 # force deflate for mangled headers developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping/
 <IfModule mod_setenvif.c>
   <IfModule mod_headers.c>
@@ -141,11 +140,14 @@ AddType text/x-vcard                   vcf
     RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
   </IfModule>
 </IfModule>
-# html, txt, css, js, json, xml, htc:
+
 <IfModule filter_module>
   FilterDeclare   COMPRESS
   FilterProvider  COMPRESS  DEFLATE resp=Content-Type /text/(html|css|javascript|plain|x(ml|-component))/
   FilterProvider  COMPRESS  DEFLATE resp=Content-Type /application/(javascript|json|xml|x-javascript)/
+  FilterProvider  COMPRESS  DEFLATE resp=Content-Type /application/(xhtml+xml|rss+xml|atom+xml|svg+xml|vnd.ms-fontobject)/
+  FilterProvider  COMPRESS  DEFLATE resp=Content-Type /image/svg+xml/
+  FilterProvider  COMPRESS  DEFLATE resp=Content-Type /font/(truetype|opentype)/
   FilterChain     COMPRESS
   FilterProtocol  COMPRESS  change=yes;byteranges=no
 </IfModule>
@@ -155,12 +157,10 @@ AddType text/x-vcard                   vcf
   AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
   AddOutputFilterByType DEFLATE text/javascript application/javascript application/x-javascript 
   AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
+  AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml application/atom+xml application/svg+xml
+  AddOutputFilterByType DEFLATE image/svg+xml application/vnd.ms-fontobject font/truetype font/opentype
 </IfModule>
 
-# webfonts and svg:
-  <FilesMatch "\.(ttf|otf|eot|svg)$" >
-    SetOutputFilter DEFLATE
-  </FilesMatch>
 </IfModule>
 
 


### PR DESCRIPTION
- Add deflate triggers for xhtml, rss, atom
- Move font & svg compression from FilesMatch to FilterProvider / AddOutputFilterByType

The first one is, IMO, more important.

The second one is just a consistency change.  We might as well use the same mechanism for all deflate triggers, rather than a mix.  Perhaps I misunderstood the need to separate out the font deflate rule, though...
