### PR TITLE
Add invalidation warning to X-UA-Compatible

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta charset="utf-8">
 
   <!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame
-       Remove this if you use the .htaccess -->
+       Remove this if you use the .htaccess  ATTN!: Breaks validation -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
   <title></title>


### PR DESCRIPTION
We had a lengthy discussion (in German) on twitter about this issue (http://out.li/ne/boilerplatevalidation), and we think it might be helpful to add a message to the X-UA-Compatible line that this breaks validation. Currently that information is hidden in the docs.
