### PR TITLE
Added DOCTYPE so Eclipse and other IDE's do not complain about the lack o

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE project>
 <project name="Boilerplate Build" default="build" basedir="../"> <!-- one back since we're in build/ -->
 
 


### PR DESCRIPTION
Added DOCTYPE so Eclipse and other IDE's do not complain about the lack of schema.
http://stackoverflow.com/questions/363768/disable-dtd-warning-for-ant-scripts-in-eclipse
