### PR TITLE
protocol-relative URL for Chrome Frame install prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
   <!-- Prompt IE 6 users to install Chrome Frame. Remove this if you want to support IE 6.
        chromium.org/developers/how-tos/chrome-frame-getting-started -->
   <!--[if lt IE 7 ]>
-    <script src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1.0.2/CFInstall.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.2/CFInstall.min.js"></script>
     <script>window.attachEvent("onload",function(){CFInstall.check({mode:"overlay"})})</script>
   <![endif]-->
   


### PR DESCRIPTION
changed the call to `CFInstall.min.js` to be protocol-relative
