### PR TITLE
Adding helper class `.scrollable` for iOS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -237,6 +237,9 @@ table { border-collapse: collapse; border-spacing: 0; }
 /* Hide visually and from screenreaders, but maintain layout */
 .invisible { visibility: hidden; }
 
+/* Enables inertial style scrolling on iOS */
+.scrollable { -webkit-overflow-scrolling: touch; overflow:scroll; }
+
 /* Contain floats: nicolasgallagher.com/micro-clearfix-hack/ */ 
 .clearfix:before, .clearfix:after { content: ""; display: table; }
 .clearfix:after { clear: both; }


### PR DESCRIPTION
We decided that inertial scrolling [doesn't belong](https://github.com/paulirish/html5-boilerplate/pull/577#issuecomment-1448173) on the `html` tag, so perhaps there should be a helper class to make applying inertial scrolling on iOS easy? 
