### PR TITLE
Fix buttons and inputs that have .ir class attached

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -220,9 +220,8 @@ table { border-collapse: collapse; border-spacing: 0; }
    ========================================================================== */
 
 /* For image replacement */
-.ir { display: block; text-indent: -999em; overflow: hidden; background-repeat: no-repeat; text-align: left; direction: ltr; }
+.ir { display: block; border: 0; text-indent: -999em; overflow: hidden; background-repeat: no-repeat; text-align: left; direction: ltr; }
 .ir br { display: none; }
-button.ir, input.ir { border: none; }
 
 /* Hide for both screenreaders and browsers:
    css-discuss.incutio.com/wiki/Screenreader_Visibility */


### PR DESCRIPTION
Every time i am working on some form where i use .ir on button on input[type=submit] or input[type=button] i must remove borders from those buttons.

So this small fix should work around that, i really think that if you are using .ir on button or those inputs - you never want border around it.

Thoughts?
