### PR TITLE
Added 5px padding to mark element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,7 +75,7 @@ hr { display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin:
 
 ins { background: #ff9; color: #000; text-decoration: none; }
 
-mark { background: #ff0; color: #000; font-style: italic; font-weight: bold; }
+mark { background: #ff0; color: #000; font-style: italic; font-weight: bold; padding: 5px; }
 
 /* Redeclare monospace font family: en.wikipedia.org/wiki/User:Davidgothberg/Test59 */
 pre, code, kbd, samp { font-family: monospace, monospace; _font-family: 'courier new', monospace; font-size: 1em; }


### PR DESCRIPTION
Pretty simple thing really. There is no padding on mark element. You can see here the how it looks:

http://jsfiddle.net/hd8gV/

I was thinking to put 10px padding on left and right, but imo it looks better with just 5px all around.
