### PR TITLE
Added hidden attribute selector alongside .hidden class

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -237,7 +237,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 
 /* Hide for both screenreaders and browsers:
    css-discuss.incutio.com/wiki/Screenreader_Visibility */
-.hidden { display: none; visibility: hidden; }
+.hidden, *[hidden] { display: none; visibility: hidden; }
 
 /* Hide only visually, but have it available for screenreaders: by Jon Neal.
   www.webaim.org/techniques/css/invisiblecontent/  &  j.mp/visuallyhidden */


### PR DESCRIPTION
Added *[hidden] selector alongside the .hidden class to hide elements with hidden attribute from browsers and screenreaders
