### PR TITLE
Image replacement of a button element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -234,6 +234,8 @@ table { border-collapse: collapse; border-spacing: 0; }
 /* For image replacement */
 .ir { display: block; border: 0; text-indent: -999em; overflow: hidden; background-repeat: no-repeat; text-align: left; direction: ltr; }
 .ir br { display: none; }
+button.ir { display: inline-block; border: 0; background-color: transparent; }
+
 
 /* Hide for both screenreaders and browsers:
    css-discuss.incutio.com/wiki/Screenreader_Visibility */


### PR DESCRIPTION
When you apply .ir class to the button element you get unwanted border, background and display property change. I propose changing default style for image replacement applied to button element so it behaves like input[type="image"] by default.
I find my self using it in many projects. It's something that I always have to reset manually and it seems to me that it would be a nice feature to get such styling in h5bp by default.
