### PR TITLE
allow access from all domains for .ttc webfont.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -62,7 +62,7 @@
 # Alternatively you could only whitelist your
 # subdomains like "subdomain.example.com".
 
-<FilesMatch "\.(ttf|otf|eot|woff|font.css)$">
+<FilesMatch "\.(ttf|ttc|otf|eot|woff|font.css)$">
   <IfModule mod_headers.c>
     Header set Access-Control-Allow-Origin "*"
   </IfModule>


### PR DESCRIPTION
Users cannot access .ttc file from all (or sub) domains.
( .ttc file has been added to application/x-font-ttf as a webfont at https://github.com/paulirish/html5-boilerplate/blob/master/.htaccess#L93 )
