### PR TITLE
add some Content-Type for Expires header.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -201,6 +201,7 @@ AddType text/x-vcard                   vcf
 
 # Your document html 
   ExpiresByType text/html                 "access plus 0 seconds"
+  ExpiresByType application/xhtml+xml     "access plus 0 seconds"
   
 # Data
   ExpiresByType text/xml                  "access plus 0 seconds"
@@ -237,6 +238,7 @@ AddType text/x-vcard                   vcf
 # CSS and JavaScript
   ExpiresByType text/css                  "access plus 1 year"
   ExpiresByType application/javascript    "access plus 1 year"
+  ExpiresByType application/x-javascript  "access plus 1 year"
   ExpiresByType text/javascript           "access plus 1 year"
   
   <IfModule mod_headers.c>


### PR DESCRIPTION
There are a few Content-type which aren't defined for Expires header though they are used in the other part of .htaccess.
- application/xhtml+xml (for XHTML5)
- application/x-javascript ( this is related to #139 )

https://github.com/paulirish/html5-boilerplate/blob/master/.htaccess#L156
https://github.com/paulirish/html5-boilerplate/blob/master/.htaccess#L171
https://github.com/paulirish/html5-boilerplate/blob/master/.htaccess#L203

I am not sure it is necessary to define them. Especially, about application/x-javascript because of the legacy.
But I think it is necessary for them to establish consistency.
