### PR TITLE
generic rewrite rules (for virtual host context)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -333,7 +333,7 @@ FileETag None
 <IfModule mod_rewrite.c>
   RewriteCond %{HTTPS} !=on
   RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-  RewriteRule ^(.*)$ http://%1/$1 [R=301,L]
+  RewriteRule ^ http://%1%{REQUEST_URI} [R=301,L]
 </IfModule>
 
 # ----------------------------------------------------------------------
@@ -346,8 +346,7 @@ FileETag None
 # <IfModule mod_rewrite.c>
 #   RewriteCond %{HTTPS} !=on
 #   RewriteCond %{HTTP_HOST} !^www\..+$ [NC]
-#   RewriteCond %{HTTP_HOST} (.+)$ [NC]
-#   RewriteRule ^(.*)$ http://www.%1/$1 [R=301,L]
+#   RewriteRule ^ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 # </IfModule>
 
 
@@ -382,7 +381,7 @@ FileETag None
 
 # <IfModule mod_rewrite.c>
 #   RewriteCond %{SERVER_PORT} !^443
-#   RewriteRule (.*) https://example-domain-please-change-me.com/$1 [R=301,L]
+#   RewriteRule ^ https://example-domain-please-change-me.com%{REQUEST_URI} [R=301,L]
 # </IfModule>
 
 


### PR DESCRIPTION
Hi from France :)

A little proposal to make rewrite rules fully compatible in all contexts : server config, virtual host, directory, .htaccess ([doc](http://httpd.apache.org/docs/current/en/mod/mod_rewrite.html#rewriterule)).

Another request I could do is about a boilerplate for **mod_cache**.
I extensively use it and it rocks :) It's like you had a proxy cache in front of Apache.
It saves you the time of generating again the same HTML output and reduce **a lot** your _TTFB_.
It works based on standard HTTP response headers (`Cache-Control`, `Expires`) that you can set manually in your business code (as PHP, for example, ensures that you deliver always fresh data overriding eventually Apache configuration).

If you are interested in, I could make a pull request and some documentation, explaining what it does and which side effect it has. At least what I have understood so far :)

PS: **H5B** défonce du poney ! (geek applause in french)
PPS: sorry for my english ^^
