### PR TITLE
Removing IE 6 image toolbar by default via .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -33,6 +33,17 @@
     </FilesMatch>
 </IfModule>
 
+# ----------------------------------------------------------------------
+# Remove IE 6 image toolbar
+# ----------------------------------------------------------------------
+
+# Kill IE6's pop-up-on-mouseover toolbar for images that can interfere with certain
+# designs and be pretty distracting in general.
+
+<IfModule mod_headers.c>
+    Header set imagetoolbar "false"
+</IfModule>
+
 
 # ----------------------------------------------------------------------
 # Cross-domain AJAX requests


### PR DESCRIPTION
Removing IE 6 image toolbar by default seems to be a good idea as this isn't present in other browsers, so it would normalize browser behavior. Description taken from Wiki.
