### PR TITLE
Replacing normalize ie6/ie7 css hacks for validity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,7 +16,8 @@
    ========================================================================== */
 
 article, aside, details, figcaption, figure, footer, header, hgroup, nav, section { display: block; }
-audio, canvas, video { display: inline-block; *display: inline; *zoom: 1; }
+audio, canvas, video { display: inline-block;}
+.ie6 audio, .ie6 canvas, .ie6 video, .ie7 audio, .ie7 canvas, .ie7 video{ display: inline; zoom: 1; }
 audio:not([controls]) { display: none; }
 [hidden] { display: none; }
 
@@ -78,7 +79,8 @@ ins { background: #ff9; color: #000; text-decoration: none; }
 mark { background: #ff0; color: #000; font-style: italic; font-weight: bold; }
 
 /* Redeclare monospace font family: h5bp.com/j */
-pre, code, kbd, samp { font-family: monospace, monospace; _font-family: 'courier new', monospace; font-size: 1em; }
+pre, code, kbd, samp { font-family: monospace, monospace; font-size: 1em; }
+.ie6 pre, .ie6 code, .ie6 kbd, .ie6 samp{ font-family: 'courier new', monospace; }
 
 /* Improve readability of pre-formatted text in all browsers */
 pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; }
@@ -143,7 +145,8 @@ label { cursor: pointer; }
  * 2. Correct alignment displayed oddly in IE6/7 
  */
 
-legend { border: 0; *margin-left: -7px; padding: 0; }
+legend { border: 0; padding: 0; }
+.ie6 legend, .ie7 legend{ margin-left: -7px; }
 
 /*
  * 1. Correct font-size not inheriting in all browsers
@@ -151,20 +154,22 @@ legend { border: 0; *margin-left: -7px; padding: 0; }
  * 3. Define consistent vertical alignment display in all browsers
  */
 
-button, input, select, textarea { font-size: 100%; margin: 0; vertical-align: baseline; *vertical-align: middle; }
+button, input, select, textarea { font-size: 100%; margin: 0; vertical-align: baseline; }
+.ie6 button, .ie6 input, .ie6 select, .ie6 textarea, .ie7 button, .ie7 input, .ie7 select, .ie7 textarea { vertical-align: middle; }
 
 /*
  * 1. Define line-height as normal to match FF3/4 (set using !important in the UA stylesheet)
  * 2. Correct inner spacing displayed oddly in IE6/7
  */
 
-button, input { line-height: normal; *overflow: visible; }
+button, input { line-height: normal; }
+.ie6 button, .ie6 input, .ie7 button, .ie7 input{ overflow: visible; }
 
 /*
  * Reintroduce inner spacing in 'table' to avoid overlap and whitespace issues in IE6/7
  */
 
-table button, table input { *overflow: auto; }
+.ie6 table button, .ie6 table input, .ie7 table button, .ie7 table input{ overflow: auto; }
 
 /*
  * 1. Display hand cursor for clickable form elements


### PR DESCRIPTION
Instead of using the ie6 and ie7 hacks in the normalize css, I used the
"paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/
" method to just replace the "*" and "_" properties. It's not a big deal
, but at least now its valid.
