### PR TITLE
Added comment to css part of index.html explaining to use @import

### DIFF
--- a/build/config/project.properties
+++ b/build/config/project.properties
@@ -78,8 +78,8 @@ env               =
 #
 # Prevent "static/" being included in concated file paths.
 #
-# gae.css_dir = /css
-# gae.js_dir = /js
+gae.css_dir = /css
+gae.js_dir = /js
 
 # Override default JSHint Options (see http://jshint.com/ for description of options)
 #tool.jshint.opts =

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
 
   <!-- CSS: implied media=all -->
   <!-- CSS concatenated and minified via ant build script-->
-  <!-- Do not reference other stylesheets here, the build-script won't include them. 
-       Use @import in style.css instead. -->
+  <!-- The build-script doesn't include these stylesheets, only those imported via
+       @import from style.css or from the project.properties file. -->
   <link rel="stylesheet" href="css/style.css">
   <!-- end CSS-->
 


### PR DESCRIPTION
Just an idea about usability -- a lot of people are trying to include css files via index.html. A brief comment explaining to use @import could be a usability improvement. Might also close Issue #677
