### PR TITLE
script.js and style.css both retain their path prefix when being swapped out for the concatenated/minified versions.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -486,7 +486,7 @@
         <concat destfile="./${dir.intermediate}/${dir.js}/scripts-concat.js" overwrite="no">
             <fileset dir="./${dir.intermediate}/">
                 <include name="${dir.js.main}/plugins.js"/>
-                <include name="${dir.js.main}/script.js"/>
+                <include name="${dir.js.main}/${file.root.script}"/>
             </fileset>
         </concat>
     </target>
@@ -551,7 +551,7 @@
               <exclude name="${dir.js}/mylibs-concat.js"/>
               <exclude name="${dir.js}/scripts-concat.min.js"/>
               <exclude name="${dir.js}/plugins.js"/>
-              <exclude name="${dir.js}/script.js"/>
+              <exclude name="${dir.js}/${file.root.script}"/>
           </fileset>
         </copy>
         <copy todir="${dir.publish}/${dir.js.mylibs}/">
@@ -608,7 +608,7 @@
 
         <echo message="Update the HTML to reference our concatenated script file: ${scripts.js}"/>
         <!-- style.css replacement handled as a replacetoken above -->
-        <replaceregexp match="&lt;!-- scripts concatenated [\d\w\s\W]*&lt;script.*src=['&quot;]?(.*)/script.js(?:\?.*)?['&quot;]?\s*&gt;\s*&lt;/script&gt;[\d\w\s\W]*&lt;!-- end ((scripts)|(concatenated and minified scripts))\s*--&gt;" 
+        <replaceregexp match="&lt;!-- scripts concatenated [\d\w\s\W]*&lt;script.*src=['&quot;]?(.*)/${file.root.script}(?:\?.*)?['&quot;]?\s*&gt;\s*&lt;/script&gt;[\d\w\s\W]*&lt;!-- end ((scripts)|(concatenated and minified scripts))\s*--&gt;" 
         	replace="&lt;script defer src='\1/${scripts.sha}.js\'&gt;&lt;/script&gt;" flags="m">
             <fileset dir="${dir.intermediate}" includes="${page-files}"/>
         </replaceregexp>
@@ -616,7 +616,7 @@
 
         <echo message="Updating the HTML with the new css filename: ${style.css}"/>
 
-        <replaceregexp match="&lt;link rel=['&quot;]?stylesheet['&quot;]?\s+href=['&quot;]?(.*)/style.css(?:\?.*)?['&quot;]?\s*&gt;" 
+        <replaceregexp match="&lt;link rel=['&quot;]?stylesheet['&quot;]?\s+href=['&quot;]?(.*)/${file.root.stylesheet}(?:\?.*)?['&quot;]?\s*&gt;" 
         	replace="&lt;link rel='stylesheet' href='\1/${css.sha}.css'&gt;" flags="m">
             <fileset dir="${dir.intermediate}" includes="${page-files}"/>
         </replaceregexp>

--- a/build/config/default.properties
+++ b/build/config/default.properties
@@ -52,6 +52,11 @@ file.default.exclude        = .gitignore, .project, .settings, README.markdown, 
 # If set, these files will not be optimized (minifications, concatinations, image optimizations will not be applied)
 # Note: you cannot declare an empty file.default.bypass property
 
+#
+# Root Script file
+# this is the file that will be swapped for the concatenated and minified javascript.
+#
+file.root.script    = script.js
 
 #
 # Root Stylesheet


### PR DESCRIPTION
Fixes #686
