### PR TITLE
Moved media queries placeholder immediately after primary styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -227,6 +227,24 @@ td { vertical-align: top; }
 
 
 
+/* ==|== media queries ======================================================
+   PLACEHOLDER Media Queries for Responsive Design.
+   These override the primary ('mobile first') styles
+   Modify as content requires.
+   ========================================================================== */
+
+@media only screen and (min-width: 480px) {
+  /* Style adjustments for viewports 480px and over go here */
+
+}
+
+@media only screen and (min-width: 768px) {
+  /* Style adjustments for viewports 768px and over go here */
+
+}
+
+
+
 /* ==|== non-semantic helper classes ========================================
    Please define your styles before this section.
    ========================================================================== */
@@ -251,24 +269,6 @@ td { vertical-align: top; }
 .clearfix:before, .clearfix:after { content: ""; display: table; }
 .clearfix:after { clear: both; }
 .clearfix { *zoom: 1; }
-
-
-
-/* ==|== media queries ======================================================
-   PLACEHOLDER Media Queries for Responsive Design.
-   These override the primary ('mobile first') styles
-   Modify as content requires.
-   ========================================================================== */
-
-@media only screen and (min-width: 480px) {
-  /* Style adjustments for viewports 480px and over go here */
-
-}
-
-@media only screen and (min-width: 768px) {
-  /* Style adjustments for viewports 768px and over go here */
-
-}
 
 
 


### PR DESCRIPTION
Moved media query placeholders immediately after primary (mobile-first) styles – **before** the non-semantic helper classes.

Sorry if I'm mistaken, I might have missed something... but it seems like this would be a more logical order, for two reasons:
1. These media query placeholders are for custom styles, which build on the mobile-first primary styles, so I think they should be consecutive.
2. The non-semantic helper classes, like `.hidden`, are supposed to come _after_ custom styles ("Please define your styles before this section"), presumably so they override custom styles?
