### PR TITLE
Set the file encoding for ant

### DIFF
--- a/build/runbuildscript.bat
+++ b/build/runbuildscript.bat
@@ -2,4 +2,5 @@
 # If you're on a mac or linux, just run `ant build` from this folder in Terminal
 
 set MYDIR=%~dp0
+set ANT_OPTS=-D"file.encoding=UTF-8"
 ant build


### PR DESCRIPTION
Resolved charset problems, if default property is not UTF-8. No more hieroglyphs.
Closes #729.
