### PR TITLE
Modify .esproj ignore rule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ Thumbs.db
 .project
 .settings
 .tmproj
-.esproj
+*.esproj
 nbproject
 
 # Dreamweaver added files


### PR DESCRIPTION
Espresso saves the project files as [project name].esproj, so the ignore rule needs to be *.esproj
