### PR TITLE
Google's auto-updating Version of jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   <!-- JavaScript at the bottom for fast page loading -->
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.3/jquery.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="js/libs/jquery-1.6.3.min.js"><\/script>')</script>
 
 


### PR DESCRIPTION
I wouldn't call it auto-updating, but, It's a pain updating the version of jQuery everytime a new release is released, this one is just like `http://code.jquery.com/jquery.min.js`

 Instead hosted on the fastest and most reliable cdns, Google's it's better `http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js` this brings the latest version of jQuery Version 1 and all of it's minor releases, when Version 2 is released, just change that to 2
