### PR TITLE
Fix small typo in createproject.sh

### DIFF
--- a/build/createproject.sh
+++ b/build/createproject.sh
@@ -38,13 +38,13 @@ else
     #create new project
     mkdir -- "$dst" || exit 1
 
-    #sucess message
+    #success message
     echo "Created Directory: $dst"
 
     cd -- "$src"
     cp -vr -- css js img build test *.html *.xml *.txt *.png *.ico .htaccess "$dst"
 
-    #sucess message
+    #success message
     echo "Created Project: $dst"
 fi
 


### PR DESCRIPTION
Fix small typos in build/createproject.sh comments: "sucess" -> "success"  | take 2!

Only included the fix in this pull request! :-)
