### PR TITLE
Fixing Google CDN's jQuery URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   <!-- JavaScript at the bottom for fast page loading -->
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.3/jquery.min.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.3/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="js/libs/jquery-1.6.3.min.js"><\/script>')</script>
 
 


### PR DESCRIPTION
I made a change to fix the Google CDN's jQuery URL 

From:   `<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>`

To:     `<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>`

Thanks,
Mohamed Alaa
