### PR TITLE
Move conditional comments to wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,6 @@
 <!doctype html>
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
-<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
-<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
-<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
-<!-- Consider adding a manifest.appcache: h5bp.com/d/Offline -->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<html class="no-js" lang="en">
 <head>
   <meta charset="utf-8">
 


### PR DESCRIPTION
The idea is to remove all conditional comments and add url for some new wiki page where people can read about this excellent technique. When you start new project you really don't need all this until you finish the project. Then you start testing in different browsers. Let's say that then you have issue with IE6 - just add conditional comments for IE6. You spot some issue in IE7? Just add another conditional comment and use this technique. win - win imo 
