### PR TITLE
Removing extra space around checkboxes and radio buttons in IE7

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -178,7 +178,7 @@ button, input[type="button"], input[type="reset"], input[type="submit"] { cursor
  * Consistent box sizing and appearance
  */
 
-input[type="checkbox"], input[type="radio"] { box-sizing: border-box; padding: 0; }
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; padding: 0; *width: 13px; *height: 13px; }
 input[type="search"] { -webkit-appearance: textfield; -moz-box-sizing: content-box; -webkit-box-sizing: content-box; box-sizing: content-box; }
 input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 


### PR DESCRIPTION
There is an extra space around checkboxes and radio buttons in IE6/7. The only way to remove it is to set their width and height to fixed size of 13px. In case of boilerplate this will work only for IE7 because IE6 doesn't support attribute selector.
