### PR TITLE
Changing IE class names to target browsers less than a version

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
-<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
-<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
-<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
+<!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!-- Consider adding a manifest.appcache: h5bp.com/d/Offline -->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>


### PR DESCRIPTION
I'm guessing there's been discussion about this before, but could only find the .oldie vs hacks stuff.

Almost all layout bugs that exist in IE8 also exist in 6 & 7, almost all layout bugs in 7 exist in 6. With class names that target versions specifically I end up repeating my selectors for IE6, 7 & 8. This pattern of selectors avoids that. Developers should be more familiar with this behaviour, as this is how it works with the underscore & star hacks.

If a style needs to be applied to IE8 specifically, it could be set on .ltie9 then overridden in .ltie8 - this isn't pretty, but I've never had to target a specific IE in practice, so I'm going on the assumption that it's an edge-case. Also means we don't need the .oldie class any more, was never keen on the naming of that.
