### PR TITLE
Help bots and visitors will find your robots.txt file no matter what

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -265,7 +265,13 @@ AddType text/x-vcard                   vcf
 #   developer.yahoo.com/performance/rules.html#etags
 FileETag None
 
-
+# CANONICAL ROBOTS.TXT http://digwp.com/2011/03/htaccess-wordpress-seo-security/#canonical-robots
+<IfModule mod_rewrite.c>
+ RewriteBase /
+ RewriteCond %{REQUEST_URI} !^/robots.txt$ [NC]
+ RewriteCond %{REQUEST_URI} robots\.txt [NC]
+ RewriteRule .* http://example.com/robots.txt [R=301,L]
+</IfModule>
 
 # ----------------------------------------------------------------------
 # Stop screen flicker in IE on CSS rollovers


### PR DESCRIPTION
This will help searchbots find the actual robots, and also it will redirect bad bots who are searching for the robots.txt all over the site to the actual robots.txt given that it is in the root, it also prevents malicious server scans
