### PR TITLE
Fix .ir helper class to work in IE6 and IE7

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -246,7 +246,8 @@ td { vertical-align: top; }
 /* For image replacement */
 .ir { display: block; border: 0; text-indent: -999em; overflow: hidden; background-color: transparent; background-repeat: no-repeat; text-align: left; direction: ltr; }
 .ir br { display: none; }
-.lt-ie8 .ir { line-height: 0; }
+/* Hide text in IE6 and IE7 */
+.ir { *line-height: 0; }
 
 /* Hide from both screenreaders and browsers: h5bp.com/u */
 .hidden { display: none !important; visibility: hidden; }


### PR DESCRIPTION
In IE6 and IE7 when you use .ir on some element text is still visible above background image, this is fix for that issue.
