### PR TITLE
Use REM for comments to avoid error messages on the DOS prompt for Window

### DIFF
--- a/build/runbuildscript.bat
+++ b/build/runbuildscript.bat
@@ -1,5 +1,5 @@
-# This is for windows users only.
-# If you're on a mac or linux, just run `ant build` from this folder in Terminal
+REM # This is for windows users only.
+REM # If you're on a mac or linux, just run `ant build` from this folder in Terminal
 
 set MYDIR=%~dp0
 set ANT_OPTS=-D"file.encoding=UTF-8"


### PR DESCRIPTION
Use REM for comments to avoid error messages on the DOS prompt for Windows users
