### PR TITLE
Including option rule to rewrite URIs to lowercase

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -354,6 +354,26 @@ FileETag None
 
 
 # ----------------------------------------------------------------------
+# Normalize case to lower in URI 
+# ----------------------------------------------------------------------
+
+# Rewrites "/PaTH/to/paGE/ -> /path/to/page/"
+# http://stackoverflow.com/questions/1998156/case-insensitive-urls-with-mod-rewrite
+
+# The RewriteMap definition must be set in the <VirtualHost> block of httpd.conf.
+# It will not work in htaccess.
+
+# RewriteEngine on
+# RewriteMap lower int:tolower
+
+# <IfModule mod_rewrite.c>
+# RewriteCond ${lower:%{REQUEST_URI}} -U
+# RewriteRule [A-Z] ${lower:%{REQUEST_URI}} [R=301,L]
+# </IfModule mod_rewrite.c>
+
+
+
+# ----------------------------------------------------------------------
 # Built-in filename-based cache busting
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
Took me a while to hunt this down, thought it might be a nice inclusion.

If you simply want to not care about the case, you can just make sure `CheckSpelling on` is set, but if you later have something server-side doing redirects, you can run into trouble.
