### PR TITLE
Cursor:pointer only needed if label has 'for' attribute

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,7 +137,7 @@ form { margin: 0; }
 fieldset { border: 0; margin: 0; padding: 0; }
 
 /* Indicate that 'label' will shift focus to the associated form element */
-label { cursor: pointer; }
+label[for] { cursor: pointer; }
 
 /*
  * 1. Correct color not inheriting in IE6/7/8/9


### PR DESCRIPTION
Added label[for] as cursor:pointer is the sole styling and this is only relevant if a click will jump to something, for which the 'for' attribute is necessary.
