### PR TITLE
edited CDN jQuery grabber

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
   <!-- JavaScript at the bottom for fast page loading -->
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.0.min.js"><\/script>')</script>
 
 


### PR DESCRIPTION
added http: to line 49 (grabbing Googles CDN jQuery). Found it not to work in Chrome whilst testing some jquery.
