### PR TITLE
Skip link for keyboard/screen reader navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -59,6 +59,9 @@ a:focus { outline: thin dotted; }
 /* Improve readability when focused and hovered in all browsers: h5bp.com/h */
 a:hover, a:active { outline: 0; }
 
+/* Skip Nav Link - this is hidden by default and shows up at the top, center if focused - more info at http://bit.ly/sOGGbb and http://bit.ly/sKG7PL */
+#skip a, #skip a:hover, #skip a:visited { position:absolute; left:-9999px; top:0px; width:1px; height:1px; overflow:hidden; z-index: 9999; text-align: center; } 
+#skip a:active, #skip a:focus { position:absolute; left:50%; margin-left: -80px; width:160px; height:auto; }
 
 /* =============================================================================
    Typography

--- a/index.html
+++ b/index.html
@@ -32,10 +32,15 @@
 </head>
 
 <body>
+  <!-- skip link for keyboard or screen reader navigation, skips to content.  Adjust the id as needed for appropriate linking 
+	   more info at http://bit.ly/sOGGbb and http://bit.ly/sKG7PL -->
+  <div id="skip">
+    <a href="#content">Skip to Main Content</a>
+  </div>
   <header>
 
   </header>
-  <div role="main">
+  <div role="main" id="content">
 
   </div>
   <footer>


### PR DESCRIPTION
Not sure if accessibility is one of the goals of h5bp, but if so, a skip link should be a pretty standard component for most websites to allow keyboard or screen reader to skip over the navigation menus directly to the content.  More info at http://bit.ly/sOGGbb and http://bit.ly/sKG7PL.

If accessibility is not a current goal, then feel free to ignore/close this pull request.
