### PR TITLE
removed _trackPageLoadTime - it's enabled by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
   <!-- Asynchronous Google Analytics snippet. Change UA-XXXXX-X to be your site's ID.
        mathiasbynens.be/notes/async-analytics-snippet -->
   <script>
-    var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview'],['_trackPageLoadTime']];
+    var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
     (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
     g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
     s.parentNode.insertBefore(g,s)}(document,'script'));


### PR DESCRIPTION
According to the [latest post](http://analytics.blogspot.com/2011/11/site-speed-now-even-easier-to-access.html) on Google Analytics blog, "`_trackPageLoadTime` is no longer required to enable Site Speed report" so I thought I can remove it.
