### PR TITLE
git ignore files do not need to ignore ignoring themselves

### DIFF
--- a/img/.gitignore
+++ b/img/.gitignore
@@ -1,2 +1,0 @@
-!.gitignore
-

--- a/js/mylibs/.gitignore
+++ b/js/mylibs/.gitignore
@@ -1,2 +1,0 @@
-!.gitignore
-


### PR DESCRIPTION
To ensure the dir exists with git, a file is required - but it can be
completely empty.

Since the git ignore file is already in the repo it is not necessary to
not-ignore it - it is already tracked.

Though trivial these !.gitignore files are being understood by some to
mean that they must contain this exact syntax to ensure an empty folder
exists.
