### PR TITLE
Removed ' <!--<![endif' from regex search string for adding manifest attribute

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -698,7 +698,7 @@
                 <copy file="${dir.intermediate}/${file.manifest}" tofile="${dir.publish}/${file.manifest}" />
 
                 <echo>Add manifest attribute to HTML: </echo>
-                <replaceregexp match="&lt;html (.*?)>\s*?&lt;!--&lt;!\[endif" replace='&lt;html \1 manifest="${file.manifest}"> &lt;!--&lt;![endif' flags="g">
+                <replaceregexp match="&lt;html (.*?)>" replace='&lt;html \1 manifest="${file.manifest}">' flags="g">
                     <fileset dir="./${dir.intermediate}" includes="${page-files}"/>
                 </replaceregexp>
 


### PR DESCRIPTION
Works fine without this segment, and no longer prevents the build script from adding the manifest attribute if the IE conditional comments are removed.
