### PR TITLE
make .htaccess (a bit) less restrictive

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -465,7 +465,7 @@ AddCharset utf-8 .html .css .js .xml .json .rss .atom
 # Block access to backup and source files
 # This files may be left by some text/html editors and 
 # pose a great security danger, when someone can access them
-<FilesMatch ".(bak|config|sql|fla|psd|ini|log|sh|inc|~|swp)$">
+<FilesMatch "\.(bak|config|sql|fla|psd|ini|log|sh|inc|~|swp)$">
   Order allow,deny
   Deny from all
   Satisfy All


### PR DESCRIPTION
The rule that made .htaccess restrict access to files (.log, .bak,
.sh, ...) was missing an escape sequence on its dot.

As a result, in addition filtering problematic files, it also filtered
some very valid urls. For example:

```
mysite.com/blog        <- satisfies /.log$/ and gets filtered
mysite.com/hit-refresh <- satisfies /.sh$/ and gets filtered
```

This change modifies .htacces so the dot is interpreted as a literal dot
character, avoiding those issues.
