### PR TITLE
Added target "copyall" in build.xml for the "dev" environment

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -240,7 +240,7 @@
     <!-- Target: basics -->
     <target name="-basics.dev"
             depends="-intro,
-                     -copy"/>
+                     -copyall"/>
 
     <target name="-basics.test"
             depends="-intro,
@@ -267,7 +267,7 @@
     <!-- Target: text -->
     <target name="-text.dev"
             depends="-intro,
-                     -copy"/>
+                     -copyall"/>
 
     <target name="-text.test"
             depends="-intro,
@@ -298,7 +298,7 @@
             depends="-intro,
                      -imagespng,
                      -imagesjpg,
-                     -copy"/>
+                     -copyall"/>
 
     <target name="-buildkit.test"
             depends="-intro,
@@ -333,7 +333,7 @@
             depends="-intro,
                      -imagespng,
                      -imagesjpg,
-                     -copy"/>
+                     -copyall"/>
 
     <target name="-build.test"
             depends="-intro,
@@ -368,7 +368,7 @@
             depends="-intro,
                      -imagespng,
                      -imagesjpg,
-                     -copy"/>
+                     -copyall"/>
 
     <target name="-minify.test"
             depends="-intro,
@@ -472,6 +472,20 @@
                 <!-- this is not strictly necessary, but it avoids putting unreferenced files into your server -->
                 <exclude name="${dir.js}/**/*.js"/>
                 <exclude name="${dir.css}/**/*.css"/>
+                <exclude name="${file.manifest}"/>
+            </fileset>
+        </copy>
+
+        <echo message="A copy of all new non-dev files are now in: ./${dir.publish}."/>
+    </target>
+
+    <target name="-copyall" depends="-mkdirs">
+    <!-- This is a private target -->
+	<!-- Copies all files, including .css and .js files for when you aren't minifying-->
+        <echo message="Copying over all files..."/>
+
+        <copy todir="./${dir.publish}">
+            <fileset dir="${dir.source}/" excludes="${file.default.exclude}, ${file.exclude}">
                 <exclude name="${file.manifest}"/>
             </fileset>
         </copy>


### PR DESCRIPTION
Fixes issue with not copying non-optimized `*.css` and `*.js` files into the publish folder. If `dev` environment is selected, .css and .js aren't minified, thus they aren't copied over with existing "copy" target.

Also, replaced the `-copy` target with `-copyall` for the `dev` builds of the following public targets:
`basics, text, buildkit, build, minify`
