### PR TITLE
Make 404 page CSS more attractive/usable

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,7 +15,7 @@
     a:hover { color: rgb(96, 73, 141); text-shadow: 2px 2px 2px rgba(36, 109, 56, 0.5); }
     input { vertical-align: middle; color: #666; padding: 10px 10px; }
     input[type=text] { margin: 0 10px 0 0; }
-    input[type=submit]:hover { color: #555; background: #ddd; cursor: pointer; }
+    input[type=submit]:hover, input[type=submit]:focus { color: #555; cursor: pointer; }
     #goog-fixurl ul { list-style: none; padding: 0; }
   </style>
 </head>


### PR DESCRIPTION
The 404 page includes some bare-bones CSS, along with a nice Google script to create/pre-populate a search form. But the CSS includes styles that make the search form less attractive and usable. This commit removes the offending styles. 

Also updated the ::selection styles to match those in `style.css`.

Be kind, this is my first attempt at using git/github!
