### PR TITLE
Adding php dist files to the blocked extensions list

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -464,7 +464,7 @@ AddCharset utf-8 .css .js .xml .json .rss .atom
 # includes directories used by version control systems such as Subversion or Git.
 <IfModule mod_rewrite.c>
   RewriteCond %{SCRIPT_FILENAME} -d
-	RewriteCond %{SCRIPT_FILENAME} -f
+  RewriteCond %{SCRIPT_FILENAME} -f
   RewriteRule "(^|/)\." - [F]
 </IfModule>
 
@@ -472,7 +472,7 @@ AddCharset utf-8 .css .js .xml .json .rss .atom
 # Block access to backup and source files
 # This files may be left by some text/html editors and
 # pose a great security danger, when someone can access them
-<FilesMatch "\.(bak|config|sql|fla|psd|ini|log|sh|inc|~|swp)$">
+<FilesMatch "\.(bak|config|sql|fla|psd|ini|log|sh|inc|~|swp|dist)$">
   Order allow,deny
   Deny from all
   Satisfy All


### PR DESCRIPTION
Some PHP libraries are using .dist files to store configuration settings. This will hide these files to the public.
