### PR TITLE
Class .ib added to css for fixing inline-block in IE

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -259,6 +259,9 @@ td { vertical-align: top; }
 /* Hide visually and from screenreaders, but maintain layout */
 .invisible { visibility: hidden; }
 
+/* Class for fixing inline-block in IE */
+.ib { zoom:1; *display: inline; }
+
 /* Contain floats: h5bp.com/q */
 .clearfix:before, .clearfix:after { content: ""; display: table; }
 .clearfix:after { clear: both; }


### PR DESCRIPTION
Felt a class should be added to the boilerplate to fix inline-block in IE. Otherwise you have to go through your document putting multiple instances of this css to each element where you need the fix. I think it's easier to just apply a class in cases where you need it.
