### PR TITLE
'CFInstall' is undefined - fix for #913

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
        chromium.org/developers/how-tos/chrome-frame-getting-started -->
   <!--[if lt IE 7 ]>
     <script defer src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js"></script>
-    <script defer>window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})</script>
+    <script defer>window.attachEvent('onload',function(){if(window.CFInstall){CFInstall.check({mode:'overlay'})}})</script>
   <![endif]-->
 
 </body>


### PR DESCRIPTION
Implementing @stereobooster's fix for a JS error with Google Chrome Frame
