### PR TITLE
Do not apply Apache Performance Tuning rule `Options -SymLinksIfOwnerMatch` by default.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -337,7 +337,7 @@ FileETag None
 # For highest performance and no symlink protection set +FollowSymLinks and -SymLinksIfOwnerMatch
 # httpd.apache.org/docs/current/misc/perf-tuning.html#symlinks
 
-Options -SymLinksIfOwnerMatch
+# Options -SymLinksIfOwnerMatch
 
 
 


### PR DESCRIPTION
Do not apply Apache Performance Tuning rule `Options -SymLinksIfOwnerMatch` by default.
Commit applied forwarding to issue #891.
