### PR TITLE
Add IDs to <header> and <footer>

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory: mathiasbynens.be/notes/touch-icons -->
 
   <link rel="stylesheet" href="css/style.css">
-  
+
   <!-- More ideas for your <head> here: h5bp.com/d/head-Tips -->
 
   <!-- All JavaScript at the bottom, except this Modernizr build incl. Respond.js
@@ -31,13 +31,13 @@
 </head>
 
 <body>
-  <header>
+  <header id="header">
 
   </header>
   <div role="main">
 
   </div>
-  <footer>
+  <footer id="footer">
 
   </footer>
 


### PR DESCRIPTION
HTML5 semantics are awesome bla bla. The `header` and `footer` elements are reusable for different things, not just the main top and bottom of every page, e.g. comments, sections of page content, lists of blog posts etc. It makes more sense to me to put an ID on the main header and footer of the site and style with `#header` and `#footer` since they are a one off thing. It means that (unless you're doing something like `body > header`) you're not blasting every header and footer element in the page, so if you want to do more <header> <footer> goodness™ in different parts of your site like you know you want to, they don't get the styles you set for your site-wide footer.

The spec has an example of multiple footers in different places.

http://dev.w3.org/html5/spec/Overview.html#the-header-element
http://dev.w3.org/html5/spec/Overview.html#the-footer-element
