### PR TITLE
Remove placeholder markup from <body>

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory: mathiasbynens.be/notes/touch-icons -->
 
   <link rel="stylesheet" href="css/style.css">
-  
+
   <!-- More ideas for your <head> here: h5bp.com/d/head-Tips -->
 
   <!-- All JavaScript at the bottom, except this Modernizr build incl. Respond.js
@@ -31,15 +31,7 @@
 </head>
 
 <body>
-  <header>
 
-  </header>
-  <div role="main">
-
-  </div>
-  <footer>
-
-  </footer>
 
 
   <!-- JavaScript at the bottom for fast page loading -->


### PR DESCRIPTION
I feel as though what's there is fairly arbitrary. For most of my stuff I'd always be adding IDs onto `<header>` and `<footer>` because I preferred it to having bulldozer selectors on all header and footer els, thus #925. However. On #203 @necolas and others think it might be a good idea to empty `<body>` completely and let people start from scratch. I think so too. Feels more boilerplatey.
