### PR TITLE
Fixes html update when using an inverse rel-href order in css link tag

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -659,7 +659,7 @@
 
         <echo message="Updating the HTML with the new css filename: ${style.css}"/>
 
-        <replaceregexp match="&lt;link rel=['&quot;]?stylesheet['&quot;]?\s+href=['&quot;]?(.*)/${file.root.stylesheet}(?:\?.*)?['&quot;]?\s*&gt;|&lt;link href=['&quot;]?(.*)/${file.root.stylesheet}(?:\?.*)?['&quot;]?\s+rel=['&quot;]?stylesheet['&quot;]?\s*&gt;"
+        <replaceregexp match="&lt;link rel=['&quot;]?stylesheet['&quot;]?\s+href=['&quot;]?(.*)/${file.root.stylesheet}(?:\?.*)?['&quot;]?\s*/?&gt;|&lt;link href=['&quot;]?(.*)/${file.root.stylesheet}(?:\?.*)?['&quot;]?\s+rel=['&quot;]?stylesheet['&quot;]?\s*/?&gt;"
         	replace="&lt;link rel='stylesheet' href='\1\2/${css.sha}.css'&gt;" flags="m">
             <fileset dir="${dir.intermediate}" includes="${page-files}"/>
         </replaceregexp>


### PR DESCRIPTION
It closes #927. Now it works with tags generated by haml and (your) default tag is working fine too.
