### PR TITLE
Remove * {filter:none} from media print due to IE9 repositioning and float issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -278,7 +278,7 @@ td { vertical-align: top; }
    ========================================================================== */
 
 @media print {
-  * { background: transparent !important; color: black !important; box-shadow:none !important; text-shadow: none !important; filter:none !important; -ms-filter: none !important; } /* Black prints faster: h5bp.com/s */
+  * { background: transparent !important; color: black !important; box-shadow:none !important; text-shadow: none !important; } /* Black prints faster: h5bp.com/s */
   a, a:visited { text-decoration: underline; }
   a[href]:after { content: " (" attr(href) ")"; }
   abbr[title]:after { content: " (" attr(title) ")"; }


### PR DESCRIPTION
In combination with html form input tags, having float:left style applied, Modernizr 2.0.6, IE9 and PIE-1.0beta6 (for rendering CSS3 properties in IE) the setting of "filter:none" causes the input elements to disappear. See it for yourself (in IE9):

http://www.kbrbeheer.nl/bugs/h5bp/stylesheet-media-print/with-filter.html
http://www.kbrbeheer.nl/bugs/h5bp/stylesheet-media-print/without-filter.html
Or when you haven't got IE9 at your disposal:
http://www.kbrbeheer.nl/bugs/h5bp/stylesheet-media-print/with-filter.pdf
http://www.kbrbeheer.nl/bugs/h5bp/stylesheet-media-print/without-filter.pdf
