### PR TITLE
restrict this header to html files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,10 +26,10 @@
 # Use ChromeFrame if it's installed for a better experience for the poor IE folk
 
 <IfModule mod_headers.c>
-  Header set X-UA-Compatible "IE=Edge,chrome=1"
-  # mod_headers can't match by content-type, but we don't want to send this header on *everything*...
-  <FilesMatch "\.(js|css|gif|png|jpe?g|pdf|xml|oga|ogg|m4a|ogv|mp4|m4v|webm|svg|svgz|eot|ttf|otf|woff|ico|webp|appcache|manifest|htc|crx|oex|xpi|safariextz|vcf)$" >
-    Header unset X-UA-Compatible
+  # mod_headers can't match by content-type, if you're dynamically creating content, you'll need
+  # to take care of sending this header (or add the file extension for your script files here)
+  <FilesMatch "\.(html|xhtml)$" >
+    Header set X-UA-Compatible "IE=Edge,chrome=1"
   </FilesMatch>
 </IfModule>
 


### PR DESCRIPTION
This is kind of an rfc.

The existing .htaccess file sets this header by default, and unsets it for any types it can determine that don't need it. This is quite a fragile strategy and results in the X-UA-Compatible header being sent for a large number of irrelevant/binary file types.

It would be more robust to send this header only when it is known to be needed - i.e. html only.
