### PR TITLE
Removing the <Location> tag from the P3P Header - Fixes issue #975

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -308,9 +308,7 @@ FileETag None
 # If needed, uncomment and specify a path or regex in the Location directive
 
 # <IfModule mod_headers.c>
-#   <Location />
-#     Header set P3P "policyref=\"/w3c/p3p.xml\", CP=\"IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT\""
-#   </Location>
+#   Header set P3P "policyref=\"/w3c/p3p.xml\", CP=\"IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT\""
 # </IfModule>
 
 

--- a/404.html
+++ b/404.html
@@ -40,4 +40,3 @@
     </script>
     <script src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
   </div>
-


### PR DESCRIPTION
The Location tag was causing a 500 error.
