### PR TITLE
Display block elements as inline inside "ir" wrap.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -251,8 +251,8 @@ td { vertical-align: top; }
 
 /* For image replacement */
 .ir { display: block; border: 0; text-indent: -999em; overflow: hidden; background-color: transparent; background-repeat: no-repeat; text-align: left; direction: ltr; *line-height: 0; }
+.ir * { display: inline; }
 .ir br { display: none; }
-.ir address, .ir article, .ir aside, .ir audio, .ir blockquote, .ir canvas, .ir dd, .ir div, .ir dl, .ir fieldset, .ir figcaption, .ir figure, .ir footer, .ir form, .ir h1, .ir h2, .ir h3, .ir h4, .ir h5, .ir h6, .ir header, .ir hgroup, .ir hr, .ir noscript, .ir ol, .ir output, .ir p, .ir pre, .ir section, .ir table, .ir tfoot, .ir ul, .ir video { display: inline; }
 
 /* Hide from both screenreaders and browsers: h5bp.com/u */
 .hidden { display: none !important; visibility: hidden; }


### PR DESCRIPTION
Fixes #991.

Due to different implementation of "text-indent" property in FF10 and IE9
inline elements after block element are not considred as first text
elements and thus are not being indented leaving them visible.

The solution is to display all block elements inside wrap element with
"ir" class as inline making all content to be one line which will be
properly indented in all browsers.

Might cuase issues if content is enormous making -999em indent not enough,
but probability of such event is minimal.

Might be clearer to use "*" selector, but it is know to have bad performance. List of 
block elements is from https://developer.mozilla.org/en/HTML/Block-level_elements.

Reported-by: erethnor
Signed-off-by: Serg Nesterov i.am.cust0dian@gmail.com
