### PR TITLE
Added placeholder text color for Firefox

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,6 +44,7 @@ body { margin: 0; font-size: 1em; line-height: 1.4; }
 
 ::-moz-selection { background: #fe57a1; color: #fff; text-shadow: none; }
 ::selection { background: #fe57a1; color: #fff; text-shadow: none; }
+:-moz-placeholder { color: #AAA; }
 
 
 /* =============================================================================


### PR DESCRIPTION
Browser-defined style for placeholder is overwritten by style for input elements in Firefox. Added :-moz-placeholder style to override that.
