### PR TITLE
Normalizing the display of disabled fields across Windows browsers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -174,6 +174,11 @@ button, input[type="button"], input[type="reset"], input[type="submit"] { cursor
 button[disabled], input[disabled] { cursor: default; }
 
 /*
+ * Normalize the display of disabled fields across Windows browsers.
+ */
+.lt-ie9 input[type="text"][disabled], .lt-ie9 textarea[disabled] { background-color: #EBEBE4; }
+
+/*
  * Consistent box sizing and appearance
  */
 


### PR DESCRIPTION
At my company we recently removed custom disabled field styling we were applying throughout our systems and falling back to the browser defaults.  What we found is that IE6 through IE9 do a pretty terrible job indicating to the user that text inputs and textareas are disabled, especially when there is no text present in the fields.

All non-IE Windows browsers apply a background-color of #EBEBE4 to disabled fields making it very evident to the end user that the field is disabled.  Interestingly enough IE10 looks to be doing this as well.  Therefore this pull request is to add the background-color to text inputs and textareas in IE7 & IE8 using the lt-ie9 class index.html applies.  The problem is also present in IE6 & IE9 but... the fields can't be targeted in IE6 because of no attribute selector support, and the boilerplate currently doesn't apply a class that can target IE9.

Here's a before and after applying this change that you can view in IE6 - IE9 the problem this is attempting to fix.
Before: http://jsfiddle.net/ygwnh/12/
After: http://jsfiddle.net/K5wDY/1/

I'm not sure if this is a big enough problem to be included in the boilerplate but I thought it was worth bringing up for discussion.  I have a more thorough write up of the problem with more examples on my blog here - http://tjvantoll.com/2012/03/17/Styling-Disabled-Form-Fields/.

Thanks.
