### PR TITLE
added a try/catch block to make log work with 'use strict'

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,6 +1,6 @@
 // usage: log('inside coolFunc', this, arguments);
 // paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
-window.log = function f(){ log.history = log.history || []; log.history.push(arguments); if(this.console) { var args = arguments, newarr; args.callee = args.callee.caller; newarr = [].slice.call(args); if (typeof console.log === 'object') log.apply.call(console.log, console, newarr); else console.log.apply(console, newarr);}};
+window.log = function f(){ log.history = log.history || []; log.history.push(arguments); if(this.console) { var args = arguments, newarr; try { args.callee = f.caller } catch(e) {}; newarr = [].slice.call(args); if (typeof console.log === 'object') log.apply.call(console.log, console, newarr); else console.log.apply(console, newarr);}};
 
 // make it safe to use console.log always
 (function(a){function b(){}for(var c="assert,count,debug,dir,dirxml,error,exception,group,groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,time,timeEnd,trace,warn".split(","),d;!!(d=c.pop());){a[d]=a[d]||b;}})


### PR DESCRIPTION
I've added a try/catch block to make the `log()` function play nice in strict mode.

The offending line (as noted in several issues filed) is `args.callee = args.callee.caller`. This line is useful in non-strict mode but serves no value in strict mode as `callee` and `caller` are not allowed, so setting the appropriate caller function on the arguments object is pointless. Thus, it made sense to me to put that line in a try/catch block to prevent it from throwing an error in strict mode yet still allowing it for non-strict use.

Here's an example of it working with "use strict"
http://jsfiddle.net/ajfym/

I also replaced `args.callee.caller` with `f.caller` (since the function is named) to save a few bytes.
