### PR TITLE
Adding other WAI-ARIA landmark roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,15 +33,17 @@
   <!-- Prompt IE 6 users to install Chrome Frame. Remove this if you support IE 6.
        chromium.org/developers/how-tos/chrome-frame-getting-started -->
   <!--[if lt IE 7]><p class=chromeframe>Your browser is <em>ancient!</em> <a href="http://browsehappy.com/">Upgrade to a different browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to experience this site.</p><![endif]-->
-  <header>
+  <header role="banner">
 
   </header>
   <div role="main">
 
   </div>
-  <footer>
+  <footer role="contentinfo">
 
   </footer>
+
+  <!-- Why the role attributes? More about WAI-ARIA: http://mcdlr.com/wai-aria-cheatsheet/ -->
 
 
   <!-- JavaScript at the bottom for fast page loading -->


### PR DESCRIPTION
I see the "main" div has the role='main' attribute. I think header and footer should also have WAI-ARIA role attributes.

It's consistent and WAI-ARIA attributes help in targeting the header or footer elements that are actually performing as page header or footers. It may seem redundant to have a header element and then say it's a header with another attribute, but the thing is WAI-ARIA attributes can not repeat (taking the role of an id) and are explicitly saying that the element is a page header or footer (remember that header and footer elements can exist may times in a single page, inside of article elements or just chilling around).

Makes sense? :)
