### PR TITLE
Add of Microsoft CDN's jQuery as a second fallback if Google CDN offline

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,9 @@
 
   <!-- JavaScript at the bottom for fast page loading -->
 
-  <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+  <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to Microsoft CDN's jQuery if offline; second fall back to local if offline -->
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+	<script>window.jQuery || document.write('<script src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-1.7.1.min.js"><\/script>')</script>
   <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.2.min.js"><\/script>')</script>
 
   <!-- scripts concatenated and minified via build script -->


### PR DESCRIPTION
Add of Microsoft CDN's jQuery as a fallback if Google CND offline and after that comes local fallback.

I am pretty new to jQuery, I just thought this could be a great Idea, if not sorry for the wasting of your time ;)
