### PR TITLE
Made local fallback easier to understand...

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.2.min.js"><\/script>')</script>
+  <script>if (!window.jQuery) document.write('<script src="js/libs/jquery-1.7.2.min.js"><\/script>')</script>
 
   <!-- scripts concatenated and minified via build script -->
   <script src="js/plugins.js"></script>


### PR DESCRIPTION
changing "window.jQuery || -document.write jquery" to "if (!window.jQuery) -document.write jquery"

I think it easily reads "If no jquery, add the local fallback"
