### PR TITLE
Espresso generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ Thumbs.db
 .project
 .settings
 .tmproj
-*.esproj
 nbproject
 *.sublime-project
 *.sublime-workspace
@@ -29,6 +28,10 @@ dwsync.xml
 # Komodo
 *.komodoproject
 .komodotools
+
+# Espresso
+*.esproj
+*.espressostorage
 
 # Folders to ignore
 .hg


### PR DESCRIPTION
Sometimes when you mess with Espresso, it generates *.espressostorage files, which you don't want to have in you repo.
