### PR TITLE
Update .gitignore to include Rubinius's compiled files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ dwsync.xml
 *.esproj
 *.espressostorage
 
+# Rubinius
+*.rbc
+
 # Folders to ignore
 .hg
 .svn


### PR DESCRIPTION
When using Rubinius, a bunch of `*.rbc` files are created.  This pull adds those files to the `.gitignore`.
