### PR TITLE
Added SASS CSS Boilerplate to CSS portion

### DIFF
--- a/css/sass/functions/_responsive-font-size.scss
+++ b/css/sass/functions/_responsive-font-size.scss
@@ -1,0 +1,16 @@
+// ==|===Responsive Font Size calculator====================
+//	Function that will calculate the responsive font size
+//	return the em value to be used.
+// =========================================================*/
+@function responsiveFontSize($fontSize: $defaultBrowserSize, $isIE: false) {
+	@if $isIE {
+		@return (($fontSize/$defaultBrowserSize) - 0.02) + em;
+	} @else {
+		@return ($fontSize/$defaultBrowserSize) + em;
+	}
+}
+
+
+@function rfs($fontSize: $defaultBrowserSize, $isIE: false) {
+	@return responsiveFontSize($fontSize, $isIE);
+}

--- a/css/sass/helper.scss
+++ b/css/sass/helper.scss
@@ -1,0 +1,63 @@
+/* ==|== non-semantic helper classes ========================================
+   Please define your styles before this section.
+   ========================================================================== */
+
+/* For image replacement */
+.ir { 
+	display: block; 
+	border: 0; 
+	text-indent: -999em; 
+	overflow: hidden; 
+	background-color: transparent; 
+	background-repeat: no-repeat; 
+	text-align: left; 
+	direction: ltr; 
+	*line-height: 0; 
+	br { 
+		display: none; 
+	}
+}
+
+/* Hide from both screenreaders and browsers: h5bp.com/u */
+.hidden { 
+	display: none !important; 
+	visibility: hidden; 
+}
+
+/* Hide only visually, but have it available for screenreaders: h5bp.com/v */
+.visuallyhidden { 
+	border: 0; 
+	clip: rect(0 0 0 0); 
+	height: 1px; 
+	margin: -1px; 
+	overflow: hidden; 
+	padding: 0; 
+	position: absolute; 
+	width: 1px; 
+	&.focusable:active, &.focusable:focus { 
+	/* Extends the .visuallyhidden class to allow the element to be focusable when navigated to via the keyboard: h5bp.com/p */
+		clip: auto; 
+		height: auto; 
+		@include add-margin();
+		overflow: visible; 
+		position: static; 
+		width: auto; 
+	}
+}
+
+/* Hide visually and from screenreaders, but maintain layout */
+.invisible { 
+	visibility: hidden; 
+}
+
+/* Contain floats: h5bp.com/q */
+.clearfix { 
+	*zoom: 1; 
+	&:before, &:after { 
+		content: ""; 
+		display: table; 
+	}
+	&:after { 
+		clear: both; 
+	}
+}

--- a/css/sass/normalize.scss
+++ b/css/sass/normalize.scss
@@ -1,0 +1,379 @@
+/*
+ * HTML5 Boilerplate
+ *
+ * What follows is the result of much research on cross-browser styling.
+ * Credit left inline and big thanks to Nicolas Gallagher, Jonathan Neal,
+ * Kroc Camen, and the H5BP dev community and team.
+ *
+ * Detailed information about this CSS: h5bp.com/css
+ *
+ * ==|== normalize ==========================================================
+ */
+
+/* =============================================================================
+   HTML5 display definitions
+   ========================================================================== */
+
+article, aside, details, figcaption, figure, footer, header, hgroup, nav, section { 
+	display: block; 
+}
+audio, canvas, video { 
+	display: inline-block; 
+	*display: inline; 
+	*zoom: 1; 
+}
+audio:not([controls]) { 
+	display: none; 
+}
+[hidden] { 
+	display: none; 
+}
+
+
+/* =============================================================================
+   Base
+   ========================================================================== */
+
+/*
+ * 1. Correct text resizing oddly in IE6/7 when body font-size is set using em units
+ * 2. Prevent iOS text size adjust on device orientation change, without disabling user zoom: h5bp.com/g
+ */
+
+html { 
+	font-size: 100%; 
+	-webkit-text-size-adjust: 100%; 
+	-ms-text-size-adjust: 100%;
+	@include normalizeFont; 
+}
+
+body { 
+	@include add-margin();
+	font-size: rfs(16); 
+	line-height: 1.4; 
+}
+
+/*
+ * Remove text-shadow in selection highlight: h5bp.com/i
+ * These selection declarations have to be separate
+ * Also: hot pink! (or customize the background color to match your design)
+ */
+
+::-moz-selection,  ::selection{ 
+	@include normalizeSelection;
+}
+
+/* =============================================================================
+   Links
+   ========================================================================== */
+
+a { 
+	color: $anchorColor; 
+	&:active {
+		/* Improve readability when focused and hovered in all browsers: h5bp.com/h */
+		outline: 0;
+	}
+	&:visited {
+		color: $anchorVisitedColor;
+	}
+	&:hover {
+		color: $anchorHoverColor;
+		outline: 0;
+	}
+	&:focus {
+		outline: thin dotted;
+	}
+}
+
+/* =============================================================================
+   Typography
+   ========================================================================== */
+
+abbr[title] { 
+	@include add-border(bottom, 1px, dotted);
+}
+
+b, strong { 
+	font-weight: bold; 
+}
+
+blockquote {
+	@include add-margin(all, 1em 40px 1em 40px); 
+}
+
+dfn { 
+	font-style: italic; 
+}
+
+hr { 
+	display: block; 
+	height: 1px; 
+	border: 0; 
+	@include add-border(top, 1px, solid, #ccc);
+	@include add-margin(all, 1em 0 1em 0); 
+	padding: 0; 
+}
+
+ins { 
+	background: #ff9; 
+	color: #000; 
+	text-decoration: none; 
+}
+
+mark { 
+	background: #ff0; 
+	color: #000; 
+	font: {
+		style: italic; 
+		weight: bold;
+	} 
+}
+
+/* Redeclare monospace font family: h5bp.com/j */
+pre, code, kbd, samp {
+	font: { 
+		family: monospace, serif; 
+		size: rfs(16);
+	} 
+	_font-family: 'courier new', monospace; 
+}
+
+/* Improve readability of pre-formatted text in all browsers */
+pre { 
+	white-space: pre; 
+	white-space: pre-wrap; 
+	word-wrap: break-word; 
+}
+
+q { 
+	quotes: none; 
+	&:before, &:after {
+		content: ""; content: none; 
+	}
+}
+
+small { 
+	font-size: 85%; 
+}
+
+/* Position subscript and superscript content without affecting line-height: h5bp.com/k */
+sub, sup { 
+	font-size: rfs(12); 
+	line-height: 0; 
+	position: relative; 
+	vertical-align: baseline; 
+}
+sup { 
+	top: -0.5em; 
+}
+sub { 
+	bottom: -0.25em; 
+}
+
+
+/* =============================================================================
+   Lists
+   ========================================================================== */
+
+ul, ol { 
+	@include add-margin(all, 1em 0 1em 0); 
+	padding: 0 0 0 40px; 
+}
+dd { 
+	@include add-margin(all, 0 0 0 40px); 
+}
+nav {
+	ul { 
+		@include noListStyle;
+	}
+	ol {
+		@include noListStyle;
+	}
+}
+
+
+/* =============================================================================
+   Embedded content
+   ========================================================================== */
+
+/*
+ * 1. Improve image quality when scaled in IE7: h5bp.com/d
+ * 2. Remove the gap between images and borders on image containers: h5bp.com/i/440
+ */
+
+img { 
+	border: 0; 
+	-ms-interpolation-mode: bicubic; 
+	vertical-align: middle; 
+}
+
+/*
+ * Correct overflow not hidden in IE9
+ */
+
+svg:not(:root) { 
+	overflow: hidden; 
+}
+
+
+/* =============================================================================
+   Figures
+   ========================================================================== */
+
+figure { 
+	@include add-margin();
+}
+
+
+/* =============================================================================
+   Forms
+   ========================================================================== */
+
+form { 
+	@include add-margin();
+}
+fieldset { 
+	border: 0; 
+	@include add-margin();
+	padding: 0; 
+}
+
+/* Indicate that 'label' will shift focus to the associated form element */
+label { 
+	@include handCursor;
+}
+
+/*
+ * 1. Correct color not inheriting in IE6/7/8/9
+ * 2. Correct alignment displayed oddly in IE6/7
+ */
+
+legend { 
+	border: 0; 
+	*margin-left: -7px; 
+	padding: 0; 
+	white-space: normal; 
+}
+
+/*
+ * 1. Correct font-size not inheriting in all browsers
+ * 2. Remove margins in FF3/4 S5 Chrome
+ * 3. Define consistent vertical alignment display in all browsers
+ */
+
+select, textarea { 
+	@include normalizeFont; 
+	font-size: rfs(16); 
+	@include add-margin();
+	vertical-align: baseline; 
+	*vertical-align: middle; 
+}
+
+button {
+	@include normalizeFont; 
+	@include normalizeInput;
+	/*
+	 * 1. Define line-height as normal to match FF3/4 (set using !important in the UA stylesheet)
+	 */
+	line-height: normal;
+	@include normalizeButton; 
+	&[disabled] {
+		/*
+		 * Re-set default cursor for disabled elements
+		 */
+		cursor: default; 
+	}
+	&::-moz-focus-inner {
+		border: 0; 
+		padding: 0; 
+	}
+}
+
+input {
+	@include normalizeFont; 
+	@include normalizeInput;
+	/*
+	 * 1. Define line-height as normal to match FF3/4 (set using !important in the UA stylesheet)
+	 */
+	line-height: normal;
+	&[type="button"], &[type="reset"], &[type="submit"] {
+		@include normalizeButton; 
+	}
+	&[disabled] {
+		/*
+		 * Re-set default cursor for disabled elements
+		 */
+		cursor: default; 
+	}
+	&[type="checkbox"], &[type="radio"] { 
+		/*
+		 * Consistent box sizing and appearance
+		 */
+		box-sizing: border-box; 
+		padding: 0; 
+		*width: 13px; 
+		*height: 13px; 
+	}
+	&[type="search"] { 
+		-webkit-appearance: textfield; 
+		-moz-box-sizing: content-box; 
+		-webkit-box-sizing: content-box; 
+		box-sizing: content-box; 
+		&::-webkit-search-decoration, &::-webkit-search-cancel-button { 
+			-webkit-appearance: none; 
+		}
+	}
+	&::-moz-focus-inner { 
+		/*
+		 * Remove inner padding and border in FF3/4: h5bp.com/l
+		 */
+		border: 0; 
+		padding: 0; 
+	}
+	&:valid {
+	}
+	&:invalid {
+		background-color: $invalidBgColor; 
+	}
+}
+
+
+/*
+ * 1. Remove default vertical scrollbar in IE6/7/8/9
+ * 2. Allow only vertical resizing
+ */
+
+textarea { 
+	overflow: auto; 
+	vertical-align: top; 
+	resize: vertical; 
+	&:valid { 
+	/* Colors for form validity */
+	}
+	&:invalid { 
+		background-color: #f0dddd; 
+	}
+}
+
+/* =============================================================================
+   Tables
+   ========================================================================== */
+
+table { 
+	border-collapse: collapse; 
+	border-spacing: 0; 
+}
+td { 
+	vertical-align: top; 
+}
+
+
+/* =============================================================================
+   Chrome Frame Prompt
+   ========================================================================== */
+
+.chromeframe { 
+	margin: 0.2em 0; 
+	background: #ccc; 
+	color: black; 
+	padding: 0.2em 0; 
+}

--- a/css/sass/partials/_media-queries.scss
+++ b/css/sass/partials/_media-queries.scss
@@ -1,0 +1,9 @@
+/* ==|== media queries ======================================================
+   EXAMPLE Media Query for Responsive Design.
+   This example overrides the primary ('mobile first') styles
+   Modify as content requires.
+   ========================================================================== */
+
+@media only screen and (min-width: 35em) {
+  /* Style adjustments for viewports that meet the condition */
+}

--- a/css/sass/partials/_mixins.scss
+++ b/css/sass/partials/_mixins.scss
@@ -1,0 +1,144 @@
+//==|== SASS mixin styles =====================================================
+// All mixins will be placed here. For more information on mixins go here:
+// http://sass-lang.com/#mixins
+// or here:
+// http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#mixins
+// Author:
+// ========================================================================== */
+
+//this mixin will set the  list-style-type to none and remove any padding
+@mixin noListStyle {
+	list-style-type: none;
+	list-style-image: none;
+	padding: 0;
+	margin: 0;
+}
+
+//This mixin will add border at given position. If no position is given (or position is all)
+//then the border will be applied to all sides
+@mixin add-border($border-position: all, $border-size: 1px, $border-pattern: solid, $border-color: #000) {
+	@if $border-position == 'all' {
+		border: $border-size $border-pattern $border-color;
+	} @else {
+		border-#{$border-position}: $border-size $border-pattern $border-color;
+	}
+}
+
+//this mixin gives the flexibility to add margins to all sides and passing the values for
+//each side, or to specify each side exclusively
+@mixin add-margin($margin-position: all, $coordinates: 0 0 0 0) {
+	@if $margin-position == 'all' {
+		$top: nth($coordinates, 1);
+		$right: nth($coordinates, 2);
+		$bottom: nth($coordinates, 3);
+		$left: nth($coordinates, 4);
+		margin: $top $right $bottom $left;
+	} @else {
+		margin-#{$margin-side}: nth($coordinates, 1);
+	}
+}
+
+//this mixin will set the border-radius for either all sides or a specified
+//side
+@mixin add-border-radius($border-radius-position: all, $border-radius: 2px) {
+	@if $border-radius-position == 'all' {
+		border-radius: $border-radius;
+	} @else {
+		border-#{$border-radius-position}-radius: $border-radius;
+	}
+}
+
+//this mixin will add the hand/pointer cursor to any element that
+//will be treated as a link/clickable
+@mixin handCursor {
+	cursor: hand;
+	cursor: pointer;
+}
+
+//this mixin will create a linear-gradient. The parameters passed here are:
+//$pos: position of the gradient which defaults to top but can take bottom, left, or right
+//$G1-G10: these allow for 10 color stops values, color and length/percentage
+//$fallback: this is the fallback color that will be used for older browsers, if this parameter
+//is not provided then the first color stop is used. 
+@mixin linear-gradient($pos, $G1, $G2: false,
+                       $G3: false, $G4: false,
+                       $G5: false, $G6: false,
+                       $G7: false, $G8: false,
+                       $G9: false, $G10: false,
+                       $fallback: false) {
+                       
+  // Detect what type of value exists in $pos
+  $pos-type: type-of(nth($pos, 1));
+
+  // If $pos is missing from mixin, reassign vars and add default position
+  @if ($pos-type == color) or (nth($pos, 1) == "transparent")  {
+    $G10: $G9; $G9: $G8; $G8: $G7; $G7: $G6; $G6: $G5;
+     $G5: $G4; $G4: $G3; $G3: $G2; $G2: $G1; $G1: $pos;
+    $pos: top; // Default position
+	}
+	
+  $full: compact($G1, $G2, $G3, $G4, $G5, $G6, $G7, $G8, $G9, $G10);
+	
+  // Set $G1 as the default fallback color
+  $fallback-color: nth($G1, 1);
+
+  // If $fallback is a color use that color as the fallback color
+  @if type-of($fallback) == color {
+    $fallback-color: $fallback;
+  }
+
+  background: $fallback-color;
+  background: deprecated-webkit-gradient(linear, $full); // Safari <= 5.0
+  background:  -webkit-linear-gradient($pos, $full); // Safari 5.1+, Chrome
+  background:     -moz-linear-gradient($pos, $full);
+  background:      -ms-linear-gradient($pos, $full);
+  background:       -o-linear-gradient($pos, $full);
+  background: unquote("linear-gradient(#{$pos}, #{$full})"); 
+}
+
+//this mixin will set the position of an element and also set the top, right, bottom, and left
+//coordinates. If no position is provided then the default position will relative
+@mixin position ($position: relative, $coordinates: 0 0 0 0) {
+
+	@if type-of($position) == list {
+		$coordinates: $position;
+		$position: relative;
+	}
+
+  $top: nth($coordinates, 1);
+  $right: nth($coordinates, 2);
+  $bottom: nth($coordinates, 3);
+  $left: nth($coordinates, 4);
+
+  position: $position;
+
+  @if not(unitless($top)) {
+    top: $top;
+  }
+
+  @if not(unitless($right)) {
+    right: $right;
+  }
+
+  @if not(unitless($bottom)) {
+    bottom: $bottom;
+  }
+
+  @if not(unitless($left)) {
+    left: $left;
+  }
+}
+
+//this mixin will set the box-shadow values. It will also allow for the felxibility of
+//doing an inset shadow.
+@mixin box-shadow ($isInset: false, $hOffset: 0, $vOffset: 0, $blur: 0, $spread: 0, $color: #ccc) {
+	@if $isInset {
+		-moz-box-shadow: inset $hOffset $vOffset $blur $spread $color;
+		-webkit-box-shadow: inset $hOffset $vOffset $blur $spread $color;
+		box-shadow: inset $hOffset $vOffset $blur $spread $color;
+	} @else {
+		-moz-box-shadow: $hOffset $vOffset $blur $spread $color;
+		-webkit-box-shadow: $hOffset $vOffset $blur $spread $color;
+		box-shadow: $hOffset $vOffset $blur $spread $color;
+	}
+}

--- a/css/sass/partials/_normalize-mixins.scss
+++ b/css/sass/partials/_normalize-mixins.scss
@@ -1,0 +1,28 @@
+@mixin normalizeFont {
+	font-family: $fontFamily; 
+	color: $fontColor; 
+}
+
+@mixin normalizeSelection {
+	background: $selectionBgColor; 
+	color: $selectionFontColor; 
+	text-shadow: none; 
+}
+
+@mixin normalizeInput {
+	font-size: rfs(16); 
+	@include add-margin();
+	vertical-align: baseline; 
+	*vertical-align: middle; 
+}
+
+@mixin normalizeButton {
+	/*
+	 * 1. Display hand cursor for clickable form elements
+	 * 2. Allow styling of clickable form elements in iOS
+	 * 3. Correct inner spacing displayed oddly in IE7 (doesn't effect IE6)
+	 */
+	@include handCursor;
+	-webkit-appearance: button; 
+	*overflow: visible; 
+}

--- a/css/sass/partials/_print.scss
+++ b/css/sass/partials/_print.scss
@@ -1,0 +1,57 @@
+/* ==|== print styles =======================================================
+   Print styles.
+   Inlined to avoid required HTTP connection: h5bp.com/r
+   ========================================================================== */
+
+@media print {
+  * { 
+  	background: transparent !important; 
+  	color: black !important; 
+  	box-shadow:none !important; 
+  	text-shadow: none !important; 
+  	filter:none !important; 
+  	-ms-filter: none !important; 
+  } /* Black prints faster: h5bp.com/s */
+  a { 
+  	text-decoration: underline; 
+	&:visited {
+	  	text-decoration: underline; 
+	}  
+	&[href]:after { 
+		content: " (" attr(href) ")"; 
+	}
+  }
+  abbr[title]:after { 
+  	content: " (" attr(title) ")"; 
+  }
+  .ir {
+  	a {
+  		&:after, &[href^="javascript:"]:after, &[href^="#"]:after { 
+  			content: ""; 
+  		}  
+  	}
+  }/* Don't show links for images, or javascript/internal links */
+  pre, blockquote { 
+  	@include add-border(all, 1px, solid, #999);
+  	page-break-inside: avoid; 
+  }
+  thead { 
+  	display: table-header-group; 
+  } /* h5bp.com/t */
+  tr, img { 
+  	page-break-inside: avoid; 
+  }
+  img { 
+  	max-width: 100% !important; 
+  }
+  @page { 
+  	margin: 0.5cm; 
+  }
+  p, h2, h3 { 
+  	orphans: 3; 
+  	widows: 3; 
+  }
+  h2, h3 { 
+  	page-break-after: avoid; 
+  }
+}

--- a/css/sass/partials/_variables.scss
+++ b/css/sass/partials/_variables.scss
@@ -1,0 +1,17 @@
+//Core variables
+$fontFamily: sans-serif;
+$fontColor: #222;
+$defaultBrowserSize: 16;
+
+//Selection colors
+$selectionBgColor: #fe57a1;
+$selectionFontColor: #fff;
+
+//Anchor colors, as you can see some of the colors are hard-coded
+//eventual goal is to set the colors based on the initial anchor color
+//and calculate the remaining
+$anchorColor: #00e;
+$anchorHoverColor: adjust-hue($anchorColor, -26deg);
+$anchorVisitedColor: #551a8b;
+
+$invalidBgColor: #f0dddd;

--- a/css/sass/style.scss
+++ b/css/sass/style.scss
@@ -1,0 +1,17 @@
+@import "partials/_variables";
+@import "functions/_responsive-font-size";
+@import "partials/_mixins";
+@import "partials/_normalize-mixins";
+@import "normalize";
+
+/* ==|== primary styles =====================================================
+   Author:
+   ========================================================================== */
+
+
+
+
+
+@import "partials/_media-queries";
+@import "helper";
+@import "partials/_print";


### PR DESCRIPTION
After using H5BP and SASS CSS, I thought it would be a good fit to include
SASS CSS in H5BP. The css file (style.css) is broken down to the following
components:
- normalize.scss: this file contains the normalize css for the boilerplate.
  Some components have been abstracted and placed in a file named
  '_normalize-mixins.scss'.
- helper.scss: this file contains the helper classes (for example .ir and
  .hidden classes).
- style.scss: this file will contain all the site specific css information.
- partials: This folder contains all the partial SASS CSS files that will
  help in abstraction of css and data. All CSS (and SASS mixins) in these
  file cannot stand on their own and require the above SASS CSS files to
  use them:
  *\* _media-queries.scss: This file will contain all the media queries
  for the responsive design implementation.
  *\* _mixins.scss: this file contains all the mixins that have been created
  (and any future mixins).
  *\* _normalize-mixins.scss: this file contains the mixins for normalize.scss file.
  *\* _print.scss: this file contains all the CSS for the print version of the site.
  *\* _variables.scss: this file contains all the variables that is used
  throughout the SASS CSS files.
- functions: this folder contains all the SASS functions created. Each function
  will be placed in their own file. For ease of use, create an overloaded
  function that will be easier to type. For eaxmple in this boilerplate I
  have created a function called 'responsive-font-size', I also have a function
  named 'rfs'.
  Note: in order to have one repository of CSS and not have to maintain the SASS and the
  regular CSS version, it would be ideal that all changes to CSS be made to the SASS version
  and compiled into style.css.
  Added by Kianosh Pourian
