### PR TITLE
CAPS LOCK DOCTYPE - why? Because we want to notice the goods things, and...

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
 <!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->


### PR DESCRIPTION
... not a non-typical small case doctype. You know a reader is going to stop for a second on this and notices change (I remember stopping on this piece)
