### PR TITLE
Update .gitignore to include AppleDouble (dot underscore) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # OS or Editor folders
 .DS_Store
+._*
 Thumbs.db
 .cache
 .project


### PR DESCRIPTION
As explained in #1070 prevent the accidental adding of <code>._*</code> files.
