### PR TITLE
+ mp3 & WebM audio formats

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -97,7 +97,9 @@ AddType application/json               json
 
 # Audio
 AddType audio/ogg                      oga ogg
+AddType audio/mp3                      mp3
 AddType audio/mp4                      m4a f4a f4b
+AddType audio/webm                     webm
 
 # Video
 AddType video/ogg                      ogv


### PR DESCRIPTION
https://developer.mozilla.org/En/Media_formats_supported_by_the_audio_and_video_elements
http://html5doctor.com/native-audio-in-the-browser/
http://transom.org/?p=26567

Silly IE9, liking only mp3 & wave.  Refrained from adding wave format; usually .zipped & meant for downloading to be used by audio editors, very rarely used for live streaming, if ever.

WebM perhaps is uncommon as an audio format, but those encoding for WebM video might notice they can do audio also.
