### PR TITLE
Add support for the seamless attribute for iframes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,6 +19,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, nav, sectio
 audio, canvas, video { display: inline-block; *display: inline; *zoom: 1; }
 audio:not([controls]) { display: none; }
 [hidden] { display: none; }
+iframe[seamless] { border: 0 none transparent; display: block; }
 
 
 /* =============================================================================


### PR DESCRIPTION
Supporting the `seamless` attribute for iframes with a tiny bit of CSS is pretty simple so I think it should be implemented. I've added support, based on the patch here: http://trac.webkit.org/changeset/115773/trunk/Source/WebCore/css/html.css#file0

For reference: http://www.whatwg.org/specs/web-apps/current-work/multipage/rendering.html#replaced-elements
