### PR TITLE
Added "http:" to the Google CDN jQuery grab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
   <!-- JavaScript at the bottom for fast page loading: http://developer.yahoo.com/performance/rules.html#js_bottom -->
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.7.2.min.js"><\/script>')</script>
 
   <!-- scripts concatenated and minified via build script -->


### PR DESCRIPTION
Unless I'm crazy, having "//" without "http:" will not cause my browser to fly out across the vast webs of the net and grab the precious jQuery.min.js which it seeks.

Chrome did not load jQuery on my end without "http:" in the url anyway.
