### PR TITLE
Add [OR] to rewrite condition

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -463,7 +463,7 @@ AddCharset utf-8 .css .js .xml .json .rss .atom
 </IfModule>
 
 
-# Block access to "hidden" directories whose names begin with a period. This
+# Block access to "hidden" directories or files whose names begin with a period. This
 # includes directories used by version control systems such as Subversion or Git.
 <IfModule mod_rewrite.c>
   RewriteCond %{SCRIPT_FILENAME} -d [OR]


### PR DESCRIPTION
The rewrite condition that looks for files and directories starting with a dot is missing an [OR] between the two conditions. The first condition checks to see if the request matches a directory and the second condition checks to see if it matches a file. Without the [OR], the condition always fails.
