### PR TITLE
Add comment on where to find more information on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-# You can find more information on how to include your own ignores and how to create a
-# global .gitignore at the GitHub:help-pages: https://help.github.com/articles/ignoring-files
+# Find out how to create a global .gitignore: http://h5bp.com/ae
 
 # Numerous always-ignore extensions
 *.diff


### PR DESCRIPTION
This comment in the `.gitignore`-file is supposed to solve some issues we had lately (#1065, #1070, #1073) with including a lot of extensions for files that are created by certain IDEs and editors. It should encourage users to set up a global .gitignore rather then relying on the HTML5 Boilerplate's .gitignore file.
This is a suggestion by @kvakes in #1065.

I'm all open to change this comment or the link where it goes.
It would be nice to have this link shortened with `h5bp.com`.

Any thoughts?
