### PR TITLE
Proper encoding (UTF-8) and MIME type (text/vtt) for WebVTT files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -130,7 +130,7 @@ AddType application/octet-stream            safariextz
 AddType application/x-web-app-manifest+json webapp
 AddType text/x-vcard                        vcf
 AddType application/x-shockwave-flash       swf
-
+AddType text/vtt                            vtt
 
 
 # ----------------------------------------------------------------------
@@ -464,7 +464,7 @@ ErrorDocument 404 /404.html
 AddDefaultCharset utf-8
 
 # Force UTF-8 for a number of file formats
-AddCharset utf-8 .css .js .xml .json .rss .atom
+AddCharset utf-8 .atom .css .js .json .rss .vtt .xml
 
 
 


### PR DESCRIPTION
From: http://dev.w3.org/html5/webvtt/#the-webvtt-file-format :

> WebVTT file must consist of a WebVTT file body **encoded as UTF-8** and labeled with the **MIME type [text/vtt](http://dev.w3.org/html5/webvtt/#text/vtt)**. 
