### PR TITLE
Shorter .clearfix with dropped IE6 and IE7 support

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -530,21 +530,13 @@ td {
 }
 
 /*
- * Contain floats: h5bp.com/q
+ * Contain floats: www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.ph
  */
 
-.clearfix:before,
 .clearfix:after {
     content: "";
     display: table;
-}
-
-.clearfix:after {
     clear: both;
-}
-
-.clearfix {
-    *zoom: 1;
 }
 
 


### PR DESCRIPTION
Since this days everyone is doping IE6 and IE7 support, you can manage with less CSS hacks and use shorter `.clearfix`. IE7 has already less than [1.4% of Worldwide usage](http://gs.statcounter.com/#browser_version-ww-monthly-201106-201206).
- No need for zoom:
  
  If you don't support IE6 and 7, then don't bother clearing floats in these browsers. And if you use `* { box-sizing: border-box }` you have even less reason to include zoom in any of your styles sheets.
- No need for `::before`
  
  We did not use `::before` for years. The only reason to add this selector was to achieve better cross browser rendering. So if we drop zoom, we can safely drop `::before` as well.

More about the updated `.clearfix` in http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php.
