### PR TITLE
Add optgroup to base section declaration

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -65,6 +65,7 @@ html,
 button,
 input,
 select,
+optgroup,
 textarea {
     font-family: sans-serif;
     color: #222;


### PR DESCRIPTION
In Firefox optgroup doesn’t inherit the font-family specified for select. See https://github.com/nathansmith/formalize/issues/41 for more infos.
