### PR TITLE
remove log()

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -6,7 +6,7 @@ if (!(window.console && console.log)) {
         var length = methods.length;
         var console = window.console = {};
         while (length--) {
-            console[methods[index]] = noop;
+            console[methods[length]] = noop;
         }
     }());
 }


### PR DESCRIPTION
Got a [great comment](http://paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/#comment-116025) on my [log() post](http://paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/) that pointed out the obvious fact that using the wrapper changes the reported line position of your logs. 

This makes clicking through to the Scripts panel far less useful, as well as losing context that a glance at the logged lines can give you. 

I think it's best to remove `log()` and recommend full use of `console.log()` with the stubbed versions for IE7.

(while we're at it, less add `timeStamp` to the console stub script.)
