### PR TITLE
Image replacement transparency needs importance

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -478,7 +478,7 @@ td {
     border: 0;
     font: 0/0 a;
     text-shadow: none;
-    color: transparent;
+    color: transparent !important;
     background-color: transparent;
 }
 


### PR DESCRIPTION
Currently the premature optimisation technique fails whenever the element would have color inherited or directly specified via a selector with more precedence than the single class `.ir` (almost all the time, in my experience). Seeing as we can't second guess authors' methods for defining colours, important is necessary.

Explained in more detail here: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757c9e03dda4e463fb0d4db5a5f82d7#commitcomment-1591111
