### PR TITLE
track 404 with GA

### DIFF
--- a/404.html
+++ b/404.html
@@ -152,6 +152,13 @@
             var GOOG_FIXURL_LANG = (navigator.language || '').slice(0,2),GOOG_FIXURL_SITE = location.host;
         </script>
         <script src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
+        <!-- mathiasbynens.be/notes/async-analytics-snippet Change UA-XXXXX-X to be your site's ID -->
+        <script>
+            var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview', '/404?p=' + encodeURIComponent(document.location.pathname + document.location.search) + '&r=' + encodeURIComponent(document.referrer)]];
+            (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
+            g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+            s.parentNode.insertBefore(g,s)}(document,'script'));
+        </script>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Not sure if we should pass `r` parameter (referer), because it is tracked by GA anyway
