### PR TITLE
More general compression configuration for Apache

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -163,36 +163,24 @@ AddType text/vtt                            vtt
     </IfModule>
   </IfModule>
 
-  # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
-  <IfModule filter_module>
-    FilterDeclare   COMPRESS
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/x-icon
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
-    FilterChain     COMPRESS
-    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
-  </IfModule>
-
-  <IfModule !mod_filter.c>
-    # Legacy versions of Apache
-    AddOutputFilterByType DEFLATE text/html text/plain text/css application/json
-    AddOutputFilterByType DEFLATE application/javascript
-    AddOutputFilterByType DEFLATE text/xml application/xml text/x-component
-    AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml application/atom+xml
-    AddOutputFilterByType DEFLATE image/x-icon image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype
+  # Compress all output labeled with one of the following MIME-types
+  <IfModule mod_filter.c>
+    AddOutputFilterByType DEFLATE application/atom+xml \
+                                  application/javascript \
+                                  application/json \
+                                  application/rss+xml \
+                                  application/vnd.ms-fontobject \
+                                  application/x-font-ttf \
+                                  application/xhtml+xml \
+                                  application/xml \
+                                  font/opentype \
+                                  image/svg+xml \
+                                  image/x-icon \
+                                  text/css \
+                                  text/html \
+                                  text/plain \
+                                  text/x-component \
+                                  text/xml
   </IfModule>
 
 </IfModule>


### PR DESCRIPTION
###### 1) Related discussion: #1012
###### 2) About the solution:
- Works with Apache ≥ 2.1 and requires `mod_deflate` and `mod_filter` to be enabled.  
   (personally, I don't think we should target lower as Apache < 2.2 is [no longer recommended](http://httpd.apache.org/docs/2.0))
- For Apache ≥ 2.1 → 2.3.7, `mod_filter` isn't needed, but I think requiring it and using this solution is the best way going forward (plus, it doesn't introduce other dependencies to other modules like, for example, [`mod_version`](http://httpd.apache.org/docs/current/mod/mod_version.html))
###### 3) Other information:
- Apache ≥ 2.3.7: 
  - `AddOutputFilterByType` was [moved into mod_filter](http://httpd.apache.org/docs/2.4/mod/mod_filter.html#addoutputfilterbytype), so the `<IfModule mod_filter.c>` condition has to be present and / or `mod_filter` has to be enabled.
  - Best solution: 
    
    ```
    <IfModule mod_deflate.c>
         # ...
         <IfModule mod_filter.c>
             AddOutputFilterByType DEFLATE application/atom+xml ...
         </IfModule>
    </IfModule>
    ```
- Apache ≥ 2.1 → 2.3.7:  
  - [`AddOutputFilterByType`](http://httpd.apache.org/docs/2.0/mod/core.html#addoutputfilterbytype) works without `mod_filter`, so there is no need to enable it or to have the `<IfModule mod_filter.c>` condition.
  - Best solution: 
    
    ```
      <IfModule mod_deflate.c>
            # ...
            AddOutputFilterByType DEFLATE application/atom+xml ...
      </IfModule>
    ```
- Apache 2.0.33 → 2.1 
  -  Apache < 2.2 is [no longer recommended](http://httpd.apache.org/docs/2.0)!
  - [`AddOutputFilterByType`](http://httpd.apache.org/docs/2.0/mod/core.html#addoutputfilterbytype) works without mod_filter and [`mod_filter` doesn't work at all](http://httpd.apache.org/docs/2.2/mod/mod_filter.html).
  - Best solution: 
    
    ```
      <IfModule mod_deflate.c>
            # ...
            AddOutputFilterByType DEFLATE application/atom+xml ...
      </IfModule>
    ```
