### PR TITLE
RFC (3023) suggests to use application/xml besides text/xml

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -179,8 +179,7 @@ AddType text/vtt                            vtt
                                   text/css \
                                   text/html \
                                   text/plain \
-                                  text/x-component \
-                                  text/xml
+                                  text/x-component
   </IfModule>
 
 </IfModule>
@@ -211,7 +210,6 @@ AddType text/vtt                            vtt
   ExpiresByType text/html                 "access plus 0 seconds"
 
 # Data
-  ExpiresByType text/xml                  "access plus 0 seconds"
   ExpiresByType application/xml           "access plus 0 seconds"
   ExpiresByType application/json          "access plus 0 seconds"
 


### PR DESCRIPTION
From the RFC ([3023](http://www.rfc-editor.org/rfc/rfc3023.txt)), under section 3, XML Media Types:

> If an XML document -- that is, the unprocessed, source XML document -- **is readable** by casual users, **text/xml** is preferable to application/xml. MIME user agents (and web user agents) that do not have explicit support for text/xml will treat it as text/plain, for example, by displaying the XML MIME entity as plain text. **Application/xml** is preferable when the XML MIME entity **is unreadable** by casual users.
