### PR TITLE
Disambiguate chromeframe prompt wording.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <!--[if lt IE 7]>
-            <p class="chromeframe">You are using an outdated browser. <a href="http://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</p>
+            <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
         <![endif]-->
 
         <!-- Add your site or application content here -->


### PR DESCRIPTION
Change "install" to "activate" so that the anchor text exactly matches the wording on the [chromeframe](http://www.google.com/chromeframe/?redirect=true) page. Plus, "activate" sounds less daunting than "install". There is less room for confusion this way. 

Many of the [people](http://www.ie6countdown.com/) who'll see the prompt will be reading translated text and/or have limited English understanding skills. The English should be as simple as possible.
