### PR TITLE
Fix the problem that console isn't exposed to window object

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -8,7 +8,7 @@
         'timeStamp', 'trace', 'warn'
     ];
     var length = methods.length;
-    var console = window.console || {};
+    window.console = window.console || {};
 
     while (length--) {
         // Only stub undefined methods.


### PR DESCRIPTION
Need to expose console to window object so that it actually works for browsers that do not have console object. Tested on IE6~9. 
