### PR TITLE
Add device-width `@viewport` CSS for IE 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ### HEAD
 
+* Enable automatic content scaling across various window dimensions in IE 10 ([#1047](https://github.com/h5bp/html5-boilerplate/issues/1047))
+
 ### 4.0.1 (20 October, 2012)
 
-* Further improvements to `console` method stubbing ([#1206](https://github.com/h5bp/html5-boilerplate/issues/1206), [#1229](https://github.com/h5bp/html5-boilerplate/pull/1229).
+* Further improvements to `console` method stubbing ([#1206](https://github.com/h5bp/html5-boilerplate/issues/1206), [#1229](https://github.com/h5bp/html5-boilerplate/pull/1229)).
 * Update to jQuery 1.8.2.
 * Update to Modernizr 2.6.2.
 * Minor additions to the documentation.

--- a/css/main.css
+++ b/css/main.css
@@ -10,6 +10,22 @@
    Base styles: opinionated defaults
    ========================================================================== */
 
+/*
+ * Enable automatic content scaling across various window dimensions in IE 10
+ */
+
+@-ms-viewport {
+    width: device-width;
+}
+
+@viewport {
+    width: device-width;
+}
+
+/*
+ * Default typography
+ */
+
 html,
 button,
 input,

--- a/doc/css.md
+++ b/doc/css.md
@@ -28,6 +28,7 @@ project](http://necolas.github.com/normalize.css/) for more information.
 This project includes a handful of base styles that build upon Normalize.css.
 These include:
 
+* Automatic content scaling across various window dimensions in IE 10.
 * Basic typography settings to provide improved text readability by default.
 * Protection against unwanted `text-shadow` during text highlighting.
 * Tweaks to default image alignment, fieldsets, and textareas.


### PR DESCRIPTION
Enable automatic content scaling in 'snap mode' and across various
window dimensions in IE 10. Include unprefixed version for the future.

Close gh-1047
