### PR TITLE
add Microsoft Office Mime-Types to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -123,6 +123,14 @@ AddType text/vtt                            vtt
 AddType text/x-component                    htc
 AddType text/x-vcard                        vcf
 
+# Microsoft Office
+AddType application/msword                                                        doc
+AddType application/vnd.ms-excel                                                  xls
+AddType application/vnd.ms-powerpoint                                             ppt
+AddType application/vnd.openxmlformats-officedocument.wordprocessingml.document   docx
+AddType application/vnd.openxmlformats-officedocument.spreadsheetml.sheet         xlsx
+AddType application/vnd.openxmlformats-officedocument.presentationml.presentation pptx
+
 
 # ----------------------------------------------------------------------
 # Allow concatenation from within specific js and css files


### PR DESCRIPTION
Versions reflected are 2003 & 2007+. Mime-Types have been taken from
its official list at Microsoft Technet

See http://technet.microsoft.com/en-us/library/ee309278(v=office.12).aspx
for details.

This came up on a discussion at h5bp/server-configs#95
