### PR TITLE
Update .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -19,10 +19,9 @@
 # Use ChromeFrame if it's installed for a better experience for the poor IE folk
 
 <IfModule mod_headers.c>
-  Header set X-UA-Compatible "IE=Edge,chrome=1"
-  # mod_headers can't match by content-type, but we don't want to send this header on *everything*...
-  <FilesMatch "\.(appcache|crx|css|eot|gif|htc|ico|jpe?g|js|m4a|m4v|manifest|mp4|oex|oga|ogg|ogv|otf|pdf|png|safariextz|svg|svgz|ttf|vcf|webm|webp|woff|xml|xpi)$">
-    Header unset X-UA-Compatible
+  # Add other webpage file extensions if necessary
+  <FilesMatch "\.(asp|html|php)$">
+    Header set X-UA-Compatible "IE=Edge,chrome=1"
   </FilesMatch>
 </IfModule>
 


### PR DESCRIPTION
Rather than setting the `X-UA-Compatible` header for all files, then unsetting it for a long list of inapplicable extensions, it may be simpler to just target a handful of common webpage file formats instead.
