### PR TITLE
Add compatibility note: "AddOutputFilterByType" is still a core module in Apache 2.2

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -164,6 +164,8 @@ AddType text/x-vcard                        vcf
   </IfModule>
 
   # Compress all output labeled with one of the following MIME-types
+  # For Apache versions below 2.3.7, remove the <IfModule>/</IfModule> lines
+  # as AddOutputFilterByType is still in the core module.
   <IfModule mod_filter.c>
     AddOutputFilterByType DEFLATE application/atom+xml \
                                   application/javascript \


### PR DESCRIPTION
See issue #1256.

This adds at least a compatibility notice for Apache < 2.3.7.

There may be also two alternatives to improve this check further:
a) Check the `API_VERSION`of the httpd module ([docs](http://www.askapache.com/security/apache-httpd-module-api-versions.html)):

```
# API Version for first Apache 2.3.7 dev release
<If "%{API_VERSION} -lt 20100609">
    # AddOutputFilterByType …
</If>
```

While this is documented, it didn't work on my default Apache on OS X Snow Leopard (v.2.2.2).

b) Check the version number with mod_version:

```
<IfModule mod_version.c>
    <IfVersion < 2.3.7>
        # AddOutputFilterByType …
    </IfVersion>
</IfModule>
```

but I'm not sure if mod_version is normally installed on production environments.
