### PR TITLE
Add boilerplate for Strict-Transport-Security headers.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -414,6 +414,21 @@ FileETag None
 
 
 # ----------------------------------------------------------------------
+# Force client-side SSL redirection
+# ----------------------------------------------------------------------
+
+# If a user types "example.com" in her browser, the above rule will redirect her
+# to the secure version of the site. That still leaves a window of opportunity
+# (the initial HTTP connection) for an attacker to downgrade or redirect the
+# request. The following header ensures that browser will **only** connect to
+# your server via HTTPS, regardless of what users type in the address bar.
+
+# <IfModule mod_headers.c>
+#   Header set Strict-Transport-Security max-age=16070400;
+# </IfModule>
+
+
+# ----------------------------------------------------------------------
 # Prevent 404 errors for non-existing redirected folders
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
`Strict-Transport-Security` headers allow a site to specify that it should **only** be visited over a secure connection. This addresses the risk of an active network attacker stripping SSL from a user's connection, or redirecting the user in the window of opportunity presented by a redirected HTTP request.
