### PR TITLE
Changed html meta charset tag to uppercase UTF-8

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
     <head>
-        <meta charset="utf-8">
+        <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title></title>
         <meta name="description" content="">


### PR DESCRIPTION
According to http://www.w3schools.com/html5/att_meta_charset.asp the list of values accepted by charset attribute of  the meta tag is here http://www.iana.org/assignments/character-sets.

This list does not include lowercase utf-8.
