### PR TITLE
remove noop function name, they are always buggy in IE

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,7 +1,7 @@
 // Avoid `console` errors in browsers that lack a console.
 (function() {
     var method;
-    var noop = function noop() {};
+    var noop = function () {};
     var methods = [
         'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
         'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',


### PR DESCRIPTION
If you're looking for a good explanation: http://kangax.github.com/nfe/#jscript-bugs

Function names are in general bad practice.
