### PR TITLE
Fix jquery link

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <!-- Add your site or application content here -->
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.8.3.min.js"><\/script>')</script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>


### PR DESCRIPTION
Fixed an issue that caused browsers (like Google Chrome) to constantly try to load //ajax.googleapis.\* and cause Dreamweaver to freeze in live view.
Adding "http:" gives the correct link to the file.
