### PR TITLE
Add the <main> element for the main content

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@
         <![endif]-->
 
         <!-- Add your site or application content here -->
-        <p>Hello world! This is HTML5 Boilerplate.</p>
+        <main role="main">
+            <p>Hello world! This is HTML5 Boilerplate.</p>
+        </main>
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.9.0.min.js"><\/script>')</script>


### PR DESCRIPTION
According to the W3C specification, the element <main>, described in
http://www.w3.org/html/wg/drafts/html/master/grouping-content.html
at 4.5.14 section, represents «the main content section of the body of
a document or of an application».

As stated below on the same section, the aria-attributes role="main"
is necessary.

This element was already styled on normalize.css
