### PR TITLE
make clearfix use IE conditional classes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -206,8 +206,8 @@ textarea {
  * Include this rule to trigger hasLayout and contain floats.
  */
 
-.clearfix {
-    *zoom: 1;
+.lt-ie8 .clearfix {
+    zoom: 1;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Albeit IE conditional classes are meant to disappear (#1290),
be consistent and make use of them while they're still here
instead of IE6/IE7 CSS hacks.
