### PR TITLE
Fix broken jQuery CDN call

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <!-- Add your site or application content here -->
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>


### PR DESCRIPTION
Google's CDN doesn't host 1.9.1 yet so this call will always fail.

https://developers.google.com/speed/libraries/devguide#jquery

On the new jQuery site, they recommend using their CDN which does host the new library. This change updates that link.

http://jquery.com/download/

Thanks for all the amazing work!
