### PR TITLE
Htacces fixes and changes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -149,17 +149,19 @@ AddType text/x-vcard                        vcf
 # This is not in use in the boilerplate as it stands. You may
 # choose to use this technique if you do not have a build process.
 
-#<FilesMatch "\.combined\.js$">
-#  Options +Includes
-#  AddOutputFilterByType INCLUDES application/javascript application/json
-#  SetOutputFilter INCLUDES
-#</FilesMatch>
+#<IfModule mod_include.c>
+#  <FilesMatch "\.combined\.js$">
+#    Options +Includes
+#    AddOutputFilterByType INCLUDES application/javascript application/json
+#    SetOutputFilter INCLUDES
+#  </FilesMatch>
 
-#<FilesMatch "\.combined\.css$">
-#  Options +Includes
-#  AddOutputFilterByType INCLUDES text/css
-#  SetOutputFilter INCLUDES
-#</FilesMatch>
+#  <FilesMatch "\.combined\.css$">
+#    Options +Includes
+#    AddOutputFilterByType INCLUDES text/css
+#    SetOutputFilter INCLUDES
+#  </FilesMatch>
+#</IfModule>
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixed issues with file concatenation. File concatenation requires the module  mod_include.so

Also added code to prevent backup (some_name.php~ ) files from showing up. This leads to security issues when config files are displayed as raw text files instead of executing them 
