### PR TITLE
Directly noop functions, remove noop variable

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,7 +1,6 @@
 // Avoid `console` errors in browsers that lack a console.
 (function() {
     var method;
-    var noop = function () {};
     var methods = [
         'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
         'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
@@ -16,7 +15,7 @@
 
         // Only stub undefined methods.
         if (!console[method]) {
-            console[method] = noop;
+            console[method] = function () {};
         }
     }
 }());


### PR DESCRIPTION
saves memory, saves bytes, perhaps it was there for readability.. I'm not sure

hate me for using github's edit feature, it's just too damn convenient
