### PR TITLE
updating pull request info link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ project:
    git push origin <topic-branch-name>
    ```
 
-10. [Open a Pull Request](http://help.github.com/send-pull-requests/) with a
+10. [Open a Pull Request](https://help.github.com/articles/using-pull-requests) with a
     clear title and description.
 
 


### PR DESCRIPTION
just wanted to make the link work in the `contributing.md` document so contributors won't get a 404 trying to view more information about pull requests and such.
