### PR TITLE
HTTPS protocol check no longer needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         <script>
             var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
             (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-            g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+            g.src='//www.google-analytics.com/ga.js';
             s.parentNode.insertBefore(g,s)}(document,'script'));
         </script>
     </body>


### PR DESCRIPTION
Google now serves all Analytics scripts via SSL also at www.google-analytics.com, so the protocol check is no longer necessary.
