### PR TITLE
Fix 404 page widget script URL

### DIFF
--- a/404.html
+++ b/404.html
@@ -151,7 +151,7 @@
             <script>
                 var GOOG_FIXURL_LANG = (navigator.language || '').slice(0,2),GOOG_FIXURL_SITE = location.host;
             </script>
-            <script src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
+            <script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Fix 404 page widget script URL to be compatible with HTTPS by replacing `http://` with `//`.

I checked the `src` and Google does have a hosted copy on SSL (https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js).
