### PR TITLE
The web is broken because webdevs assume bg is always white

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -16,11 +16,14 @@ input,
 select,
 textarea {
     color: #222;
+    background: #fff;
 }
 
 body {
     font-size: 1em;
     line-height: 1.4;
+    color: #222;
+    background: #fff;
 }
 
 /*


### PR DESCRIPTION
I propose this change to land in HTML5 boilerplate by default.

Web developers keep assuming the background to be white without
explicitly defining it. Because of that, a huge number of websites
are foundamentally broken on any slightly more "exotic" system. I
use a dark system theme and every other page has black text on
system-default dark browser background. Changing browser custom
css is no solution, because it breaks more than it fixes.

By making this a part of H5BP some web developers might notice
and stop making broken websites.

![css_fail](https://f.cloud.github.com/assets/761287/315748/03c58d7c-97f2-11e2-8101-2e62f3040350.png)
