### PR TITLE
Added "apple-mobile-web-app-title" to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="apple-mobile-web-app-title" content="">
 
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 


### PR DESCRIPTION
When "Add to Home Screen" is selected, the apple-mobile-web-app-title meta tag gives the option to add your sites short name instead of "untitled document"
