### PR TITLE
added support for text/javascript deflating in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -400,6 +400,7 @@ AddDefaultCharset utf-8
                                       text/html \
                                       text/plain \
                                       text/x-component \
+                                      text/javascript \
                                       text/xml
     </IfModule>
 


### PR DESCRIPTION
Some applications and servers return `text/javascript` and not `application/javascript` as a mime type for javascript files and as a result these files weren't being gzipped.  Even though the official mime type is 'application/javascript' as [per stackoverflow.](http://stackoverflow.com/questions/876561/when-serving-javascript-files-is-it-better-to-use-the-application-javascript-or)

An example is Google's own [CDN](https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js)
![Capture](https://f.cloud.github.com/assets/1382005/438624/9650b148-b0d0-11e2-8746-8f91410bcc12.PNG)
