### PR TITLE
Change window.jQuery to this.jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
+        <script>this.jQuery || document.write('<script src="js/vendor/jquery-1.9.1.min.js"><\/script>')</script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>
 


### PR DESCRIPTION
Ok, I am probably missing something here, a fast look into the issues did not highlight any discussion.
Is there a reason for this being window.jQuery instead of this.jQuery?
That could be a micro gain of 2 chars -.-
