### PR TITLE
Wrong Internet Explorer Update Website

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <!--[if lt IE 7]>
-            <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
+            <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://windows.microsoft.com/en-us/internet-explorer/download-ie">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
         <![endif]-->
 
         <!-- Add your site or application content here -->


### PR DESCRIPTION
The correct URL to upgrade Internet Explorer is `http://windows.microsoft.com/en-us/internet-explorer/download-ie` and not `http://www.browsehappy.com/`.
