### PR TITLE
Removed outline: 0 for imrpoved accessibility

### DIFF
--- a/css/normalize.css
+++ b/css/normalize.css
@@ -98,19 +98,11 @@ body {
 
 /**
  * Address `outline` inconsistency between Chrome and other browsers.
+ * Keep outline for improved accessiblity.
  */
 
-a:focus {
+a:focus, a:active, a:hover {
     outline: thin dotted;
-}
-
-/**
- * Improve readability when focused and also mouse hovered in all browsers.
- */
-
-a:active,
-a:hover {
-    outline: 0;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Removed outline: 0 from a:active and a:hover in normalize to improve accessibility. 

Added the same style currently used for a:focus.

See @kcunning, so we won't be the worst person in the world anymore.
