### PR TITLE
Add default white background color to inputs to complement default #222 foreground color - avoids unreadable text for users with dark themes.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -11,17 +11,8 @@
    ========================================================================== */
 
 html,
-button,
-input,
-select,
-textarea {
+button {
     color: #222;
-}
-
-input,
-select,
-textarea {
-   background-color: #fff;
 }
 
 body {


### PR DESCRIPTION
Users on systems who chose a dark theme - for aesthetic preferences or because dark backgrounds aide their vision (ex. colorblind) - have inverted system default foreground and background colors. CSS designers often change just the foreground color, assuming the background will be white. This causes unreadable black/almost black text on a black background. Many many sites do this, including ones that should know better, for example:

![gmail](https://f.cloud.github.com/assets/439208/689520/2a683e9c-dab5-11e2-955f-0f8fabcba65a.png)

If one is going to set a foreground color, one should also set a complementary background color. If HTML5 Boilerplate was diligent about this it would have a wide effect.
