### PR TITLE
Remove unneeded directory check in filename-based cache busting

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -413,7 +413,6 @@ FileETag None
 # Uncomment to enable.
 # <IfModule mod_rewrite.c>
 #   RewriteCond %{REQUEST_FILENAME} !-f
-#   RewriteCond %{REQUEST_FILENAME} !-d
 #   RewriteRule ^(.+)\.(\d+)\.(js|css|png|jpg|gif)$ $1.$3 [L]
 # </IfModule>
 


### PR DESCRIPTION
I know this technique can be used to bust whole dirs, but that is not the case in this code sample.
