### PR TITLE
Meta Viewport tag currently in use is broken on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="description" content="">
 
     <!-- Mobile viewport optimized: h5bp.com/viewport -->
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory: mathiasbynens.be/notes/touch-icons -->
 


### PR DESCRIPTION
Using only `width=device-width` causes iOS to fix the width and not update on orientation change. Including `initial-scale=1.0` solves this issue. Take a look at the [viewport test](http://snugug.github.io/viewport-test/) I've made.
