### PR TITLE
Fix webkit font smoothing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -21,6 +21,10 @@ textarea {
 body {
     font-size: 1em;
     line-height: 1.4;
+    -webkit-font-smoothing: subpixel-antialiased !important;
+    -webkit-backface-visibility: hidden;
+    -moz-backface-visibility: hidden;
+    -ms-backface-visibility: hidden;
 }
 
 /*


### PR DESCRIPTION
There are bug in default webkit @font-face rendering. 
https://code.google.com/p/chromium/issues/detail?id=152304

I think everybody, who use @font-face, knows that in chrome it looks monstrous.

This should make sure text smoothing looks good.

https://code.google.com/p/chromium/issues/detail?id=152304#c135
