### PR TITLE
Set color for disabled form elements

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -24,6 +24,17 @@ body {
 }
 
 /*
+ * Set color for disabled form elements.
+ */
+
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+   color: #808080;
+}
+
+/*
  * Remove text-shadow in selection highlight: h5bp.com/i
  * These selection rule sets have to be separate.
  * Customize the background color to match your design.


### PR DESCRIPTION
Setting the color on form elements (e.g. button) also overwrites the disabled styles of the user agent: http://jsfiddle.net/rmHKu/1/

Therefore it is necessary to explicitly set the disabled style: http://jsfiddle.net/LfAUR/1/
