### PR TITLE
Move font-size delaration to html element

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -18,7 +18,7 @@ textarea {
     color: #222;
 }
 
-body {
+html {
     font-size: 1em;
     line-height: 1.4;
 }


### PR DESCRIPTION
Since rems are based on the `font-size` of the html element we should probably move the `font-size` declaration there. This would set up reasonable expectations for the developer (edit `font-size`, change rems) without changing any current behavior (`body { font-size: 1em }` is implied).

The original commit to add `body { font-size: 1em }` is [here](https://github.com/h5bp/html5-boilerplate/commit/380c4f80d83f8bca72f315bfa6a15b0c1af5b596). It seems it was added as a developer convenience, while `line-height` needed normalization.
