### PR TITLE
Add column number to the javascript error tracking

### DIFF
--- a/doc/extend.md
+++ b/doc/extend.md
@@ -456,12 +456,12 @@ Add this function after `_gaq` is defined:
             a.href = href;
             return a;
         };
-    window.onerror = function (message, file, row) {
+    window.onerror = function (message, file, line, column) {
         var host = link(file).hostname;
         _gaq.push([
             '_trackEvent',
             (host == window.location.hostname || host == undefined || host == '' ? '' : 'external ') + 'error',
-            message, file + ' LINE: ' + row, undefined, undefined, true
+            message, file + ' LINE:' + line + (column ? ' COLUMN:' + column : ''), undefined, undefined, true
         ]);
     };
 }(window));


### PR DESCRIPTION
A column number parameter has been added to the [spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#errorevent) and has already been [implemented in Chrome and IE10](https://code.google.com/p/chromium/issues/detail?id=264197)
