### PR TITLE
Fix comment in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <!-- Place favicon.ico and apple-touch-icon-precomposed.png in the root directory -->
 
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">


### PR DESCRIPTION
Comment related to favicon and Apple touch icon refers to missing file (apple-touch-icon.png) replaced by apple-touch-icon-precomposed.png.

It is small oversight but it could confuse some developers ;)
