### PR TITLE
Fix header typo in `doc/html.md`

### DIFF
--- a/doc/html.md
+++ b/doc/html.md
@@ -100,7 +100,7 @@ The central part of the boilerplate template is pretty much empty. This is
 intentional, in order to make the boilerplate suitable for both web page and
 web app development.
 
-### BrowseHappy Promt
+### BrowseHappy Prompt
 
 The main content area of the boilerplate includes a prompt to install an up to
 date browser for users of IE 6/7. If you intended to support IE 6/7, then you


### PR DESCRIPTION
Fix typo: Promt/Prompt
