### PR TITLE
Fix for Chrome for OSX when printing pages with select tags

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -291,4 +291,8 @@ textarea {
     h3 {
         page-break-after: avoid;
     }
+
+    select {
+        background: #fff !important;
+    }
 }


### PR DESCRIPTION
On Chrome for OSX (both stable 30 and beta 31), make a print preview of this page:
http://jsfiddle.net/tagliala/HWSgZ/

You will see full-page height vertical shadows on both sides of the select box

This issue was also reported to chromium: https://code.google.com/p/chromium/issues/detail?id=311975

Screenshots are available here: https://github.com/twbs/bootstrap/issues/11245
