### PR TITLE
Remove CSS helper classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Remove image replacement helper class `.ir`
 * Update to Apache Server Configs 2.0.0.
 * Add vertical centering for `svg` ([#1453](https://github.com/h5bp/html5-boilerplate/issues/1453)).
 * Redesign 404 page ([#1443](https://github.com/h5bp/html5-boilerplate/pull/1443)).

--- a/css/main.css
+++ b/css/main.css
@@ -119,23 +119,6 @@ textarea {
    ========================================================================== */
 
 /*
- * Image replacement
- */
-
-.ir {
-    background-color: transparent;
-    border: 0;
-    overflow: hidden;
-}
-
-.ir:before {
-    content: "";
-    display: block;
-    width: 0;
-    height: 150%;
-}
-
-/*
  * Hide from both screenreaders and browsers: h5bp.com/u
  */
 
@@ -251,7 +234,6 @@ textarea {
      * Don't show links for images, or javascript/internal links
      */
 
-    .ir a:after,
     a[href^="javascript:"]:after,
     a[href^="#"]:after {
         content: "";

--- a/doc/css.md
+++ b/doc/css.md
@@ -38,13 +38,6 @@ You are free to modify or add to these base styles as your project requires.
 
 ## Common helpers
 
-#### `.ir`
-
-Add the `.ir` class to any element you are applying image-replacement to. When
-replacing an element's content with an image, make sure to also set a specific
-`background-image: url(pathtoimage.png);`, `width`, and `height` so that your
-replacement image appears.
-
 #### `.hidden`
 
 Add the `.hidden` class to any elements that you want to hide from all


### PR DESCRIPTION
The following CSS helper classes get removed from `main.css`:
- Image replacement: `.ir`
- Hidden elements: `.hidden`
- Visually hidden elements: `.visuallyhidden`
- Visually hidden elements that are focussable via keybord:
  `.visuallyhidden.focusable`
- Invisible elements: `.invisible`
- Clearfix: `.clearfix`

These classes were removed because they don't provide enough use cases within
modern web development. Cases are mostly handled indiviually by developers.

All the helper code is retained in the [`v4`](https://github.com/h5bp/html5-boilerplate/tree/v4) branch.

Reference #1472.

Please feel free to provide feedback and discuss this commit here.
