### PR TITLE
Add comment on lang attribute on <html>

### DIFF
--- a/doc/html.md
+++ b/doc/html.md
@@ -9,6 +9,14 @@ Allows you to more easily explicitly add custom styles when JavaScript is
 disabled (`no-js`) or enabled (`js`). More here: [Avoiding the
 FOUC](http://paulirish.com/2009/avoiding-the-fouc-v3/).
 
+## Language attribute
+
+Please consider specifying the language of your content by adding the `lang`
+attribute to `<html>` as in this example:
+
+```html
+<html class="no-js" lang="en">
+```
 
 ## The order of meta tags, and `<title>`
 


### PR DESCRIPTION
We don't set a default lang-attribute on <html> due to the discussion in #1110. This commit adds a note about how to set it.
