### PR TITLE
Hide url bar in iOS7.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title></title>
         <meta name="description" content="">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
 
         <!-- Place favicon.ico and apple-touch-icon(s) in the root directory -->
 


### PR DESCRIPTION
A property, minimal-ui, has been added for the viewport meta tag key that allows minimizing the top and bottom bars on the iPhone as the page loads. While on a page using minimal-ui, tapping the top bar brings the bars back. Tapping back in the content dismisses them again.

For example, use <meta name=”viewport” content=”width=1024, minimal-ui”>.

http://www.everythingicafe.com/forum/threads/lets-talk-ios-7-1-beta-2.104595/
