### PR TITLE
Remove meta charset

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="no-js">
     <head>
-        <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title></title>
         <meta name="description" content="">


### PR DESCRIPTION
According to the HTML5 Specification on [determining the encoding](http://www.w3.org/html/wg/drafts/html/master/syntax.html#determining-the-character-encoding) of a page, the browser should take the content-type set in the header of the packet and use that, then abort looking any further for a character set.

> Step four: If the transport layer specifies a character encoding, and it is supported, return that encoding with the confidence certain, and abort these steps.

Because of this, I believe it would be best that we recommend that developers have their backends set the proper encoding type on generated content if they already don't do so. Then any static content should simply be saved at UTF-8. Doing this would reduce the total page size, which means less bits going across the wire and more space in packets for other things. Overall, reduce page size, which could mean fewer round trips for serving content, which both equal faster sites.

Since the meta charset tag shouldn't even be recognized by browsers unless a content-type header is missing should we continue to recommend its inclusion in sites?
