### PR TITLE
fix "Missing 'use strict' statement" warning from jshint

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,6 +1,7 @@
 // Avoid `console` errors in browsers that lack a console.
 (function() {
     'use strict';
+
     var method;
     var noop = function () {};
     var methods = [


### PR DESCRIPTION
jshint with default values complains about the missing 'use strict' statement in the plugin.js console function.
