### PR TITLE
serve index.html with bundle install; bundle exec rackup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Include your project-specific ignores in this file
 # Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
+
+/.bundle/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem 'rack'

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,14 @@
+use Rack::Static,
+  :urls => ["/img", "/js," "/css"],
+  :root => "."
+
+run lambda { |env|
+  [
+    200,
+    {
+      'Content-Type'  => 'text/html',
+      'Cache-Control' => 'public, max-age=86400'
+    },
+    File.open('index.html', File::RDONLY)
+  ]
+}


### PR DESCRIPTION
The first thing I wanted to do with the boilerplate was inspect it in my browser.  For various reasons (chromebook, security extensions in my browser), I couldn't just open it with a file url.

I took the most basic rackup configuration you could do to serve just the index page.  Since I found it useful, I thought I'd offer it up.  I won't be offended if you don't find it useful.

All it requires to work is a working ruby install and running two commands:

```
bundle install
bundle exec rackup
```

Thanks for boilerplate and cheers.
