### PR TITLE
Make Git (and thus, GitHub) exclude some files when generating an archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 * text=auto
+
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+img/.gitignore export-ignore
+LICENSE.md export-ignore
+README.md export-ignore


### PR DESCRIPTION
GitHub generates two archives (`.zip` and `.tar.gz`) for every tag / release we create. This is useful as we can provide the links to those archives to users to download a specific version of our project.

However, these archives contain all files the project had when the tag / release was made. This includes files that aren't of any use to the users, and are most likely going to be deleted (e.g.: `CONTRIBUTING.md`).

This commit whitelists the files that aren't useful for users and informs Git (and thus, GitHub) not to include them when generating an archive.

Ref: http://git-scm.com/book/en/Customizing-Git-Git-Attributes#Exporting-Your-Repository

---

The current whitelisted files are: 
- `CHANGELOG.md` 
- `CONTRIBUTING.md`
- `LICENSE.md` (maybe this shouldn't be removed?)
- `README.md` 

(I'll update this list if we decide to change something)

Thoughts?

---

**EDIT:**  Since we provide the `.gitattributes` file, one problem with this change is that users will also get this whitelist (and that can potentially causing some unexpected behavior). :(
