### PR TITLE
Add 'auto' to the Google Analytics tracker create method.

### DIFF
--- a/doc/extend.md
+++ b/doc/extend.md
@@ -140,7 +140,7 @@ snippet](http://mathiasbynens.be/notes/async-analytics-snippet#universal-analyti
 included with HTML5 Boilerplate includes something like this:
 
 ```js
-ga('create','UA-XXXXX-X'); ga('send','pageview');
+ga('create', 'UA-XXXXX-X', 'auto'); ga('send', 'pageview');
 ```
 
 To customize further, see Google's [Advanced
@@ -159,7 +159,7 @@ parameter](https://developers.google.com/analytics/devguides/collection/analytic
 before sending any events/pagviews. In use it looks like this:
 
 ```js
-ga('create','UA-XXXXX-X');
+ga('create', 'UA-XXXXX-X', 'auto');
 ga('set', 'anonymizeIp', true);
 ga('send', 'pageview');
 ```

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-XXXXX-X');ga('send','pageview');
+            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>


### PR DESCRIPTION
Google Analytics supports [automatic cookie domain configuration](https://developers.google.com/analytics/devguides/collection/analyticsjs/domains#auto), and this is now officially part of the recommended [GA code snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/).

When this parameter is omitted (as it was prior to this pull request), Google Analytics will default to using `location.hostname`, which will include the subdomain. This prevents websites with multiple subdomains from being able to automatically track unique users across those subdomains.
