### PR TITLE
Docs: Remove `minimal-ui` related information

### DIFF
--- a/doc/extend.md
+++ b/doc/extend.md
@@ -569,13 +569,6 @@ Home Screen icon. This works since iOS 6.
 <meta name="apple-mobile-web-app-title" content="">
 ```
 
-On iOS 7.1, you can minimize the top and bottom bars on the iPhone as the page
-loads, simply by adding the `minimal-ui` property to the `viewport` meta tag.
-
-```html
-<meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
-```
-
 For further information please read the [official
 documentation](http://developer.apple.com/library/safari/#documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html)
 on Apple's site.


### PR DESCRIPTION
From https://developer.apple.com/library/prerelease/ios/releasenotes/General/RN-iOSSDK-8.0/#//apple_ref/doc/uid/TP40014223-CH1-SW83: 

>  The minimal-ui viewport property is no longer supported in iOS 8.
## 

The [`minimal-ui`](https://github.com/h5bp/html5-boilerplate/pull/1485) viewport property was introduced in iOS 7.1, and it seems that it will no longer be supported in iOS 8, so I think we shouldn't encourage its usage anymore.
