### PR TITLE
Doc/faq.md: added `php -S` way to start a server

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -38,6 +38,9 @@ Setting up a local server can be done using:
   [MAMP](http://www.mamp.info/en/index.html),
   [WAMP](http://www.wampserver.com/en/), or
   [XAMPP](http://www.apachefriends.org/index.html)
+* If you're running OSX, you can start a simple php server by running 
+  `php -S localhost:8888` in your local directory, then open `http://localhost:8888`
+  in a browser. If, for some reason, port 8888 won't work for you, try another port number.
 
 
 ### Why don't you automatically load the latest version of jQuery from the Google CDN?


### PR DESCRIPTION
In faq.md, I added the `php` command as a way to start a local webserver. I personally think it's a really easy way to start a simple local webserver, and it's build-in for OSX 10.9 or higher.

![1__user_imac-van-arthur-2____documents_sites_urlshort__zsh_](https://cloud.githubusercontent.com/assets/6025224/3733545/2df86186-1709-11e4-9082-f822790d51e1.png)
