### PR TITLE
Add noindex meta tag to 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Page Not Found</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
     <style>
 
         * {


### PR DESCRIPTION
Since nobody wants search engines to index a 404 page, I think it's a good idea to add a `noindex` meta tag to `404.html`. This meta tag will ensure that search engines aren't indexing broken links.

Reference: [https://support.google.com/webmasters/answer/93710?hl=en](https://support.google.com/webmasters/answer/93710?hl=en)
