### PR TITLE
Removes gulp-rimraf from gulpfile in favor of del()

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var del = require('del');
 
 var gulp = require('gulp');
 var plugins = require('gulp-load-plugins')(); // Load all gulp plugins
@@ -49,21 +50,18 @@ gulp.task('archive:zip', function (done) {
             'mode': fs.statSync(filePath)
         });
 
-    })
+    });
 
     archiver.pipe(output);
     archiver.finalize();
 
 });
 
-gulp.task('clean', function () {
-    return gulp.src([
+gulp.task('clean', function (cb) {
+    del([
         template('<%= archive %>', dirs),
         template('<%= dist %>', dirs)
-    ], {
-        read: false // Prevent gulp from reading the content of
-                    // the files in order to make this task faster
-    }).pipe(plugins.rimraf());
+    ], cb);
 });
 
 gulp.task('copy', [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "apache-server-configs": "2.7.1",
     "archiver": "^0.10.1",
+    "del": "^0.1.1",
     "glob": "^4.0.5",
     "gulp": "^3.8.6",
     "gulp-header": "^1.0.5",
@@ -9,7 +10,6 @@
     "gulp-load-plugins": "^0.5.3",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.4.0",
-    "gulp-rimraf": "^0.1.0",
     "jquery": "1.11.1",
     "jshint-stylish": "^0.4.0",
     "lodash": "^2.4.1",


### PR DESCRIPTION
Related to https://github.com/h5bp/html5-boilerplate/issues/1578
