### PR TITLE
Add pseudo-elements to universal selector in print media query

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -201,7 +201,9 @@ textarea {
    ========================================================================== */
 
 @media print {
-    * {
+    *,
+    *:before,
+    *:after {
         background: transparent !important;
         color: #000 !important; /* Black prints faster: h5bp.com/s */
         box-shadow: none !important;


### PR DESCRIPTION
The pseudo-elements `:before` and `:after` are not targeted by the universal `*` selector. When the page is printed the CSS properties of any pseudo-elements will only be overridden if they are being inherited from their selector. Any styles that have been defined directly on a pseudo-element are unaffected.
