### PR TITLE
Fix typo in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task('archive:zip', function (done) {
     var archiver = require('archiver')('zip');
     var files = require('glob').sync('**/*.*', {
         'cwd': dirs.dist,
-        'dot': true, // include hiddent files
+        'dot': true, // include hidden files
     });
     var output = fs.createWriteStream(archiveName);
 


### PR DESCRIPTION
Fixed little typo in a comment inside of the gulpfile.
