### PR TITLE
Docs: Update icon size for Chrome Mobile web apps

### DIFF
--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -643,7 +643,7 @@ which tries to be a more generic replacement to Apple's proprietary meta tag:
 Same applies to the touch icons:
 
 ```html
-<link rel="icon" sizes="196x196" href="highres-icon.png">
+<link rel="icon" sizes="192x192" href="highres-icon.png">
 ```
 
 


### PR DESCRIPTION
According to the Chrome documentation, we should use 192px image

https://developer.chrome.com/multidevice/android/installtohomescreen#icon
