### PR TITLE
Make Travis automatically update `dist` directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@
 # in this file, please see the Travis CI documentation:
 # http://docs.travis-ci.com
 
+after_success:
+  - npm run update_dist_directory
+
+env:
+  global:
+    - secure: "Nke4Gka/Jk642dmSQWbMlg+a6KYE+7pb/P/ovperX0z/wU8jksuP+UznEDWLIow/RUCP83snDZViVsHzENlgDNAOHeTOCELqy5EdN5vzGKYaMblqzfg8RFE6xt0+PghnyFT+iOlCar7HXFB8yAIhp95wbtvWxEas2IAqOB1zo4A="
+
 git:
   depth: 10
 

--- a/bin/update_dist_directory.sh
+++ b/bin/update_dist_directory.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# [!] This script is intended for Travis. If the tests pass, Travis will
+# automatically execute this script, regenerating the `dist` directory and
+# committing any new changes to the `master` branch.
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+commit_and_push_changes() {
+
+    # Check if there are unstaged changes, and
+    # if there are, commit and push them upstream
+
+    if [ $(git diff --exit-code > /dev/null; printf $?;) -eq 1 ]; then
+        git config --global user.email ${GH_USER_EMAIL} \
+            && git config --global user.name ${GH_USER_NAME} \
+            && git checkout master &> /dev/null \
+            && git add -A \
+            && git commit --message "Update content from the \`dist\` directory [skip ci]" > /dev/null \
+            && git push --quiet "$(get_repository_url)" master > /dev/null
+        print_result $? "Commit and push changes"
+    fi
+
+}
+
+get_repository_url() {
+    printf "https://${GH_TOKEN}@$(git config --get remote.origin.url | sed 's/git:\/\///g')"
+}
+
+print_error() {
+    # Print output in red
+    printf "\e[0;31m [✖] $1\e[0m\n"
+}
+
+print_result() {
+    [ $1 -eq 0 ] \
+        && print_success "$2" \
+        || print_error "$2"
+
+    if [ $1 -ne 0 ]; then
+        exit 1
+    fi
+}
+
+print_success() {
+    # Print output in green
+    printf "\e[0;32m [✔] $1\e[0m\n"
+}
+
+update_content() {
+    npm -q install \
+        && npm run build > /dev/null
+    print_result $? "Update content"
+}
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+main() {
+
+    # Only execute the following if the
+    # changes were made in the `master` branch
+
+    if [ "$TRAVIS_BRANCH" == "master" ]; then
+        update_content
+        commit_and_push_changes
+    fi
+
+}
+
+main

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "name": "html5-boilerplate",
   "private": true,
   "scripts": {
-    "test": "gulp archive && mocha --reporter spec --timeout 5000"
+    "build": "gulp build",
+    "test": "gulp archive && mocha --reporter spec --timeout 5000",
+    "update_dist_directory": "bin/update_dist_directory.sh"
   },
   "version": "4.3.0"
 }


### PR DESCRIPTION
Configure Travis to automatically update the content from the `dist` directory by executing a script¹ that will regenerate the content from the `dist` directory and commit any new changes to the `master` branch.

This change will help in the development process by:
- ensuring that the content from the `dist` directory is always in sync with the rest of the content
- removing the need to execute the build step locally everytime a change is made (especially in the case of trivial changes, such as, typos)

---

¹ The script (`bin/update_dist_directory.sh`) will only be executed if the tests pass, and will only run if the changes are made in the `master` branch.

Ref: http://docs.travis-ci.com/user/encryption-keys/
