### PR TITLE
Docs: fixed broken link in `usage.md`

### DIFF
--- a/src/doc/usage.md
+++ b/src/doc/usage.md
@@ -98,7 +98,7 @@ Edit this file to include any pages you need hidden from search engines.
 ### crossdomain.xml
 
 A template for working with cross-domain requests. [About
-crossdomain.xml](crossdomain.md).
+crossdomain.xml](misc.md#crossdomainxml).
 
 ### Icons
 


### PR DESCRIPTION
The `crossdomain.xml` docs aren't anymore in `crossdomain.md`, but are now part of `misc.md`. The link in `usage.md` was still pointing to `crossdomain.md`.
