### PR TITLE
Updated BrowseHappy prompt to be site-agnostic

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -77,10 +77,10 @@ textarea {
 }
 
 /* ==========================================================================
-   Browse Happy prompt
+   Browser Upgrade Prompt
    ========================================================================== */
 
-.browsehappy {
+.browserupgrade {
     margin: 0.2em 0;
     background: #ccc;
     color: #000;

--- a/dist/doc/html.md
+++ b/dist/doc/html.md
@@ -129,7 +129,7 @@ The central part of the boilerplate template is pretty much empty. This is
 intentional, in order to make the boilerplate suitable for both web page and
 web app development.
 
-### BrowseHappy Prompt
+### Browser Upgrade Prompt
 
 The main content area of the boilerplate includes a prompt to install an up to
 date browser for users of IE 6/7. If you intended to support IE 6/7, then you

--- a/dist/index.html
+++ b/dist/index.html
@@ -15,7 +15,7 @@
     </head>
     <body>
         <!--[if lt IE 8]>
-            <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
 
         <!-- Add your site or application content here -->

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -75,10 +75,10 @@ textarea {
 }
 
 /* ==========================================================================
-   Browse Happy prompt
+   Browser Upgrade Prompt
    ========================================================================== */
 
-.browsehappy {
+.browserupgrade {
     margin: 0.2em 0;
     background: #ccc;
     color: #000;

--- a/src/doc/html.md
+++ b/src/doc/html.md
@@ -129,7 +129,7 @@ The central part of the boilerplate template is pretty much empty. This is
 intentional, in order to make the boilerplate suitable for both web page and
 web app development.
 
-### BrowseHappy Prompt
+### Browser Upgrade Prompt
 
 The main content area of the boilerplate includes a prompt to install an up to
 date browser for users of IE 6/7. If you intended to support IE 6/7, then you

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
     </head>
     <body>
         <!--[if lt IE 8]>
-            <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
 
         <!-- Add your site or application content here -->


### PR DESCRIPTION
Per the discussion in #1582, this simply replaces all explicit references to BrowseHappy with more site-agnostic wording.
