### PR TITLE
Add `bugs` key to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "bugs": {
+    "url": "https://github.com/h5bp/html5-boilerplate/issues"
+  },
   "devDependencies": {
     "apache-server-configs": "2.9.0",
     "archiver": "^0.11.0",


### PR DESCRIPTION
From https://www.npmjs.org/doc/files/package.json.html#bugs:

> The url to your project's issue tracker and / or the email address to which issues should be reported.

However this is a 'private' package, and thus this isn't super important I would still include it. 
