### PR TITLE
Remove unnecessary rule in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,4 +19,3 @@ trim_trailing_whitespace = false
 # The indent size used in the `package.json` file cannot be changed
 # https://github.com/npm/npm/pull/3180#issuecomment-16336516
 indent_size = 2
-indent_style = space


### PR DESCRIPTION
Line 11 already states all files should be using spaces, so this line saying it again isn't necessary. Or is there a specific reason this was included?
