### PR TITLE
Addition of Meta Theme Colour Markup

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,8 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-
+        <!-- Theme colour for Chrome UI bleed on Android -->
+        <meta name="theme-color" content="#fff">
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
         <!-- Place favicon.ico in the root directory -->
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,8 +6,7 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <!-- Theme colour for Chrome UI bleed on Android -->
-        <meta name="theme-color" content="#fff">
+
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
         <!-- Place favicon.ico in the root directory -->
 

--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -643,3 +643,15 @@ Same applies to the touch icons:
 ```html
 <link rel="icon" sizes="192x192" href="highres-icon.png">
 ```
+
+### Theme Colour
+
+Theme colour for Chrome UI bleed on Android.
+For Colour Bleed/theme colour on Chrome UI on
+Android (inline with current colour bleed trends, such as Yosemite/iOS8
+etc).
+
+Content attribute should be a 6 digit hex code (at least for the moment, until official Moz docs are relased).
+```html
+<meta name="theme-color" content="#ffffff">
+```


### PR DESCRIPTION
Added suggested meta tag: For Colour Bleed/theme colour on Chrome UI on
Android (inline with current colour bleed trends, such as Yosemite/iOS8
etc).