### PR TITLE
Add DNS Prefetching for included external domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Add DNS Prefetching for included external domains
 * Update Apache Server Configs to v2.11.0.
 * Rename Apple touch icon to `apple-touch-icon.png` and add
   `<link>` in `index.html`

--- a/dist/index.html
+++ b/dist/index.html
@@ -2,6 +2,8 @@
 <html class="no-js" lang="">
     <head>
         <meta charset="utf-8">
+        <link rel="dns-prefetch" href="//ajax.googleapis.com">
+        <link rel="dns-prefetch" href="//www.google-analytics.com">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title></title>
         <meta name="description" content="">

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,8 @@
 <html class="no-js" lang="">
     <head>
         <meta charset="utf-8">
+        <link rel="dns-prefetch" href="//ajax.googleapis.com">
+        <link rel="dns-prefetch" href="//www.google-analytics.com">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title></title>
         <meta name="description" content="">


### PR DESCRIPTION
This has been brought twice previously that I can find: https://github.com/h5bp/html5-boilerplate/pull/468 and https://github.com/h5bp/html5-boilerplate/pull/965.

However both introduced prefetching for domains that weren't actually used in the default `index.html` and required customization.

I also don't believe that one of the [original reasons](https://github.com/h5bp/html5-boilerplate/pull/468#issuecomment-1059525) against it applies to this situation.

The reasoning behind this PR is simple: both `ajax.googleapis.com` and `www.google-analytics.com` are used by default in H5BP and would benefit from being prefetched.
