### PR TITLE
Change meta tag x-ua position

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html class="no-js" lang="">
     <head>
-        <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta charset="utf-8">
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
In this link: http://msdn.microsoft.com/en-us/library/ie/jj676915(v=vs.85).aspx has a quote:

> The X-UA-Compatible header isn't case sensitive; however, it must appear in the header of the webpage (the HEAD section) before all other elements except for the title element and other meta elements.

But this exception isn't true. If the X-UA-Compatible don't be put before all other elements in `<head>`, the IE ignore this tag.