### PR TITLE
Improved CDN and analytics

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta http-equiv="x-ua-compatible" content="IE=edge">
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,7 +12,11 @@
 
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">
-        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+        <script>
+            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
+            window.Modernizr||b('js/vendor/modernizr-2.8.3.min.js')
+        </script>
     </head>
     <body>
         <!--[if lt IE 8]>
@@ -23,18 +27,15 @@
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-        <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+        <script>window.jQuery||b('js/vendor/jquery-1.11.2.min.js')</script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='//www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})
+            g[a].l=+new Date;b('//www.google-analytics.com/analytics.js')}(window,'ga'));
+            ga('create', 'UA-XXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -24,7 +24,6 @@
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
         <script>
-            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
             window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
         </script>
         <script src="js/plugins.js"></script>
@@ -32,6 +31,7 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
+            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
             (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})
             g[a].l=+new Date;b('//www.google-analytics.com/analytics.js')}(window,'ga'));
             ga('create', 'UA-XXXX-X','auto');ga('send','pageview');

--- a/dist/index.html
+++ b/dist/index.html
@@ -24,15 +24,15 @@
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
         <script>
-            (function(){function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
+            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
                         
-              //here include the fallbacks you want - format: test||b('path/to/local.js')
-              window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
+            //here include the fallbacks you want - format: (condition)||b('path/to/local.js')
+            window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
               
-              //below is the Google Analytics snippet: change UA-XXXXX-X to be your site's ID
-              (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})
-              g[a].l=+new Date;b('//www.google-analytics.com/analytics.js')}(window,'ga'));
-              ga('create', 'UA-XXXX-X','auto');ga('send','pageview')})
+            //below is the google analytics snippet
+            (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})
+            g[a].l=+new Date;b('//www.google-analytics.com/analytics.js')}(window,'ga'));
+            ga('create', 'UA-XXXX-X','auto');ga('send','pageview')
               
         </script>
         <script src="js/plugins.js"></script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -27,7 +27,7 @@
             function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
                         
             //here include the fallbacks you want - format: (condition)||b('path/to/local.js')
-            window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
+            window.jQuery||b('js/vendor/jquery-1.11.2.min.js');
               
             //below is the google analytics snippet
             (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})

--- a/dist/index.html
+++ b/dist/index.html
@@ -12,11 +12,7 @@
 
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">
-        <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
-        <script>
-            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
-            window.Modernizr||b('js/vendor/modernizr-2.8.3.min.js')
-        </script>
+        <script src="js/vendor/modernizr-2.8.3.min.js"></script>
     </head>
     <body>
         <!--[if lt IE 8]>
@@ -27,7 +23,10 @@
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-        <script>window.jQuery||b('js/vendor/jquery-1.11.2.min.js')</script>
+        <script>
+            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
+            window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
+        </script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -24,17 +24,18 @@
 
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
         <script>
-            window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
+            (function(){function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
+                        
+              //here include the fallbacks you want - format: (condition)||b('path/to/local.js')
+              window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
+              
+              //below is the Google Analytics snippet: change UA-XXXXX-X to be your site's ID
+              (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})
+              g[a].l=+new Date;b('//www.google-analytics.com/analytics.js')}(window,'ga'));
+              ga('create', 'UA-XXXX-X','auto');ga('send','pageview')})
+              
         </script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>
-
-        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
-        <script>
-            function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
-            (function(g,a){g.GoogleAnalyticsObject=a;g[a]||(g[a]=function(){(g[a].q=g[a].q||[]).push(arguments)})
-            g[a].l=+new Date;b('//www.google-analytics.com/analytics.js')}(window,'ga'));
-            ga('create', 'UA-XXXX-X','auto');ga('send','pageview');
-        </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -26,7 +26,7 @@
         <script>
             (function(){function b(o,i,l,r){i=document;l='script';r=i.createElement(l);r.src=o;i.getElementsByTagName(l)[0].parentNode.appendChild(r)}
                         
-              //here include the fallbacks you want - format: (condition)||b('path/to/local.js')
+              //here include the fallbacks you want - format: test||b('path/to/local.js')
               window.jQuery||b('js/vendor/jquery-1.11.2.min.js')
               
               //below is the Google Analytics snippet: change UA-XXXXX-X to be your site's ID


### PR DESCRIPTION
Added global function for CDN fallbacks, 
Modernizr is served with CDN as well (the cdn itsef can be changed)
Made use of it on the analytics snippet
(don't mind the "x-ua-compatible" yet, still on open issue: #1656)
### pros:
* less characters:
  with modernizr fallback: 465 against 525
  without modernizr: 410 against 433
  (counted with the spaces in " || " removed)
* xml compatible (no _document.write_ or something that look like an element)
* useful for make a fallback for any other script 

### cons:
* can't use _b_ as variable in scripts - __can easily be changed__
* __need testing__ to see if the analitycs snippet really works 
