### PR TITLE
Further optimizing Google Analytics snippet

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -29,9 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i){b.GoogleAnalyticsObject='g';(b.g=b.g||function(){(b.g.q=b.g.q||[]).push(arguments)}).l=+new Date;
-            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'
-            }(window,document,'script'));g('create','UA-XXXXX-X','auto');g('send','pageview');
+            (function(b,o,i,l){b.GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
+            (window,document,'script','g'));g('create','UA-XXXXX-X','auto');g('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -32,7 +32,7 @@
             (function(b,o,i,l,r){b.GoogleAnalyticsObject=i;
             b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});l='script';b[i].l=+new Date;
             o.getElementsByTagName(l)[0].parentNode.appendChild(r=o.createElement(l));r.src='//www.google-analytics.com/analytics.js'}(window,document,'ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview')
+            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -31,7 +31,7 @@
         <script>
             GoogleAnalyticsObject=l='ga';
             ((b=window)[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
-            (o=document).getElementsByTagName(i='script')[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics_debug.js';
+            (o=document).getElementsByTagName(i='script')[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js';
             ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,7 +29,8 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
+            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function(){
+            (b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
             o.getElementsByTagName(l)[0].parentNode.appendChild(o.createElement(l)).src='//www.google-analytics.com/analytics.js'}
             (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -31,7 +31,7 @@
         <script>
             (function(b,o,i,l){b.GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'script','g'));g('create','UA-XXXXX-X','auto');g('send','pageview');
+            (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,10 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            GoogleAnalyticsObject=l='ga';
-            ((b=window)[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
-            (o=document).getElementsByTagName(i='script')[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js';
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+          (function(b,o,i,l){GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+          o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
+          (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,7 +29,8 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            GoogleAnalyticsObject=l='ga';((b=window)[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+            GoogleAnalyticsObject=l='ga';
+            ((b=window)[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
             (o=document).getElementsByTagName(i='script')[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics_debug.js';
             ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,11 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'script','ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(b,o,i){b.GoogleAnalyticsObject='g';b.g||(b.g=function(){(b.g.q=b.g.q||[]).push(arguments)});b.g.l=+new Date;
+            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'
+            }(window,document,'script'));g('create','UA-XXXXX-X','auto');g('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,7 +29,7 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i){b.GoogleAnalyticsObject='g';b.g||(b.g=function(){(b.g.q=b.g.q||[]).push(arguments)});b.g.l=+new Date;
+            (function(b,o,i){b.GoogleAnalyticsObject='g';(b.g||(b.g=function(){(b.g.q=b.g.q||[]).push(arguments)})).l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'
             }(window,document,'script'));g('create','UA-XXXXX-X','auto');g('send','pageview');
         </script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -32,7 +32,7 @@
             (function(b,o,i,l){GoogleAnalyticsObject=l;(b[l]=b[l]||
             function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i))
-            .src='//www.google-analytics.com/analytics.js'}(window,document,'script','ga'));
+            .src='https://www.google-analytics.com/analytics.js'}(window,document,'script','ga'));
             ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,9 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-          (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
+            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
             o.getElementsByTagName(l)[0].parentNode.appendChild(o.createElement(l)).src='//www.google-analytics.com/analytics.js'}
-           (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,9 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
-            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'script','g'));g('create','UA-XXXXX-X','auto');g('send','pageview');
+            GoogleAnalyticsObject=l='ga';((b=window)[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+            (o=document).getElementsByTagName(i='script')[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics_debug.js';
+            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,11 +29,10 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l,r){b.GoogleAnalyticsObject=i;b[i]||(b[i]=
-            function(){(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;l='script';
-            o.getElementsByTagName(l)[0].parentNode.appendChild(r=o.createElement(l));
-            r.src='//www.google-analytics.com/analytics.js'}(window,document,'ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function()
+            {(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
+            o.getElementsByTagName(l)[0].parentNode.appendChild(o.createElement(l)).src='//www.google-analytics.com/analytics.js'}
+            (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');  
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -30,7 +30,7 @@
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
             (function(b,o,i,l,r){b.GoogleAnalyticsObject=i;b[i]||(b[i]=
-            function(){(b[i].q=b[i].q||[]).push(arguments)});l='script';b[i].l=+new Date;
+            function(){(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;l='script';
             o.getElementsByTagName(l)[0].parentNode.appendChild(r=o.createElement(l));
             r.src='//www.google-analytics.com/analytics.js'}(window,document,'ga'));
             ga('create','UA-XXXXX-X','auto');ga('send','pageview');

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,9 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-          (function(b,o,i,l){GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
-          o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-          (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(b,o,i,l){GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
+            (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -31,7 +31,7 @@
         <script>
             (function(b,o,i,l){b.GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (window,document,'script','g'));g('create','UA-XXXXX-X','auto');g('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,8 +29,8 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){GoogleAnalyticsObject=l;
-            (b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+            (function(b,o,i,l){GoogleAnalyticsObject=l;(b[l]=b[l]||
+            function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i))
             .src='//www.google-analytics.com/analytics.js'}(window,document,'script','ga'));
             ga('create','UA-XXXXX-X','auto');ga('send','pageview');

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,10 +29,9 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function()
-            {(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
+          (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
             o.getElementsByTagName(l)[0].parentNode.appendChild(o.createElement(l)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');  
+           (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,10 +29,11 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[l]||(b[l]=function(){
-            (b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
+            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[l]||(b[l]=
+            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (window,document,'script','ga'));
+            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,9 +29,11 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){GoogleAnalyticsObject=l;(b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
-            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(b,o,i,l){GoogleAnalyticsObject=l;
+            (b[l]=b[l]||function(){(b[l].q=b[l].q||[]).push(arguments)}).l=+new Date;
+            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i))
+            .src='//www.google-analytics.com/analytics.js'}(window,document,'script','ga'));
+            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,9 +29,10 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l,r){b.GoogleAnalyticsObject=i;
-            b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});l='script';b[i].l=+new Date;
-            o.getElementsByTagName(l)[0].parentNode.appendChild(r=o.createElement(l));r.src='//www.google-analytics.com/analytics.js'}(window,document,'ga'));
+            (function(b,o,i,l,r){b.GoogleAnalyticsObject=i;b[i]||(b[i]=
+            function(){(b[i].q=b[i].q||[]).push(arguments)});l='script';b[i].l=+new Date;
+            o.getElementsByTagName(l)[0].parentNode.appendChild(r=o.createElement(l));
+            r.src='//www.google-analytics.com/analytics.js'}(window,document,'ga'));
             ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,7 +29,7 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i){b.GoogleAnalyticsObject='g';(b.g||(b.g=function(){(b.g.q=b.g.q||[]).push(arguments)})).l=+new Date;
+            (function(b,o,i){b.GoogleAnalyticsObject='g';(b.g=b.g||function(){(b.g.q=b.g.q||[]).push(arguments)}).l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'
             }(window,document,'script'));g('create','UA-XXXXX-X','auto');g('send','pageview');
         </script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,12 +29,10 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='//www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(b,o,i,l,r){b.GoogleAnalyticsObject=i;
+            b[i]||(b[i]=function(){(b[i].q=b[i].q||[]).push(arguments)});l='script';b[i].l=+new Date;
+            o.getElementsByTagName(l)[0].parentNode.appendChild(r=o.createElement(l));r.src='//www.google-analytics.com/analytics.js'}(window,document,'ga'));
+            ga('create','UA-XXXXX-X','auto');ga('send','pageview')
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,10 +29,10 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[i]||(b[i]=function(){
-            (b[i].q=b[i].q||[]).push(arguments)});b[i].l=+new Date;
-            o.getElementsByTagName(l)[0].parentNode.appendChild(o.createElement(l)).src='//www.google-analytics.com/analytics.js'}
-            (window,document,'ga','script'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[l]||(b[l]=function(){
+            (b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
+            o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
+            (window,document,'script','ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -29,7 +29,7 @@
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
         <script>
-            (function(b,o,i,l){b.GoogleAnalyticsObject=i;b[l]||(b[l]=
+            (function(b,o,i,l){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
             function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
             o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i)).src='//www.google-analytics.com/analytics.js'}
             (window,document,'script','ga'));


### PR DESCRIPTION
__EDIT__: it started to be a real mess in this post so i cleared it up

this is a shorter (and still safe) version of the google analytics snippet - 322 charcters against 346
it does exactly the same - except adding the script after the first script in the document rather than before it. only one function changed - `insertBefore` to `appendChild` to eliminate the need for one of the parameters, all the rest is done by syntax manipulation __ONLY__
this is a bit more readable version (same code just added whitespace:
```
(function (b, o, i, l) {
    GoogleAnalyticsObject = l;
    (b[l] = b[l] || function () {
        (b[l].q = b[l].q || []).push(arguments)}
    ).l = +new Date;
    o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i))
    .src='//www.google-analytics.com/analytics.js'}
(window, document, 'script', 'ga'));ga('create', 'UA-XXXXX-X', 'auto');ga('send', 'pageview');
```
let go line by line:
__new__ `(function (b, o, i, l) {` __old__ `(function(b,o,i,l,e,r)`
not much to say we need less parameters
__new__ `GoogleAnalyticsObject = l;` __old__ `b.GoogleAnalyticsObject=l;`
the window object is assumed if no object specified (except for conditional statements)
__new__ `(b[l] = b[l] || function () {` __old__ `b[l] || (b[l] = function () {`
shorter syntax and we can use it 2 lines later
__new__ `(b[l].q = b[l].q || []).push(arguments)}` __old__ `(b[l].q = b[l].q || []).push(arguments)}`
no change here
__new__ `).l = +new Date;` __old__ `);b[l].l = +new Date;`
we use the functio0n it self as the object instead of referencing it
__new__ 
```
o.getElementsByTagName(i)[0].parentNode.appendChild(o.createElement(i))
.src='//www.google-analytics.com/analytics.js'}
```
__old__ 
```
e=o.createElement(i);r=o.getElementsByTagName(i)[0];
e.src='//www.google-analytics.com/analytics.js';
r.parentNode.insertBefore(e,r)}
```
by changing to appendChild we do not need reference anymore and we declare anything inside the functions - using the original value and saving the need for a parameter
__new__ `(window, document, 'script', 'ga'));ga('create', 'UA-XXXXX-X', 'auto');ga('send', 'pageview');` __old__ `(window, document, 'script', 'ga'));ga('create','UA-XXXXX-X','auto');ga('send','pageview');`
also the same

I've checked this script with google analytics debugger, also with multiple trackers
it works (no reason why not)
@mathiasbynens - feel free to update your article about it if you like
