### PR TITLE
Remove redundant 'visibility: hidden' from .hidden

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -122,7 +122,6 @@ textarea {
 
 .hidden {
     display: none !important;
-    visibility: hidden;
 }
 
 /*

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -120,7 +120,6 @@ textarea {
 
 .hidden {
     display: none !important;
-    visibility: hidden;
 }
 
 /*


### PR DESCRIPTION
The preceding rule of `display: none` is all that is
needed to hide an element, thus rendering the
visibility rule redundant.

https://github.com/h5bp/html5-boilerplate/issues/1663