### PR TITLE
Docs: Added missing period

### DIFF
--- a/dist/doc/js.md
+++ b/dist/doc/js.md
@@ -20,7 +20,7 @@ other 3rd party scripts.
 One approach is to put jQuery plugins inside of a `(function($){ ...
 })(jQuery);` closure to make sure they're in the jQuery namespace safety
 blanket. Read more about [jQuery plugin
-authoring](http://docs.jquery.com/Plugins/Authoring#Getting_Started)
+authoring](http://docs.jquery.com/Plugins/Authoring#Getting_Started).
 
 By default the `plugins.js` file contains a small script to avoid `console`
 errors in browsers that lack a `console`. The script will make sure that, if


### PR DESCRIPTION
The second paragraph under plugins.js has had a missing period added at its end:

One approach is to put jQuery plugins inside of a (function($){ ... })(jQuery); closure to make sure they're in the jQuery namespace safety blanket. Read more about jQuery plugin authoring.