### PR TITLE
add .htaccess to linguist-vendored

### DIFF
--- a/dist/.gitattributes
+++ b/dist/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+.htaccess linguist-vendored


### PR DESCRIPTION
Project have a massive .htaccess file , so GitHub linguist think that ApacheConf a primary language and GitHub repo marked as ApacheConf. I suggest to add .htaccess file in .gitattributes and mark it as linguist-vendored, and then linguist will ignore it and show correct project language.