### PR TITLE
Added gulp-autoprefixer task to the project

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@ var fs = require('fs');
 var path = require('path');
 
 var gulp = require('gulp');
-var autoprefixer = require('gulp-autoprefixer');
 var plugins = require('gulp-load-plugins')(); // Load all gulp plugins
                                               // automatically and attach
                                               // them to the `plugins` object
@@ -100,6 +99,12 @@ gulp.task('copy:main.css', function () {
                .pipe(plugins.header(banner))
                .pipe(gulp.dest(dirs.dist + '/css'));
 
+    return gulp.src('css/main.css')
+                .pipe(plugins.autoprefixer({
+                    browsers: ['last 2 versions', 'ie >= 8'],
+                    cascade: false
+                }))
+                .pipe(gulp.dest('dist'));
 });
 
 gulp.task('copy:misc', function () {
@@ -135,15 +140,6 @@ gulp.task('lint:js', function () {
       .pipe(plugins.jshint())
       .pipe(plugins.jshint.reporter('jshint-stylish'))
       .pipe(plugins.jshint.reporter('fail'));
-});
-
-gulp.task('default', function () {
-    return gulp.src('css/main.css')
-        .pipe(autoprefixer({
-            browsers: ['last 2 versions'],
-            cascade: false
-        }))
-        .pipe(gulp.dest('dist'));
 });
 
 // ---------------------------------------------------------------------

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 
 var gulp = require('gulp');
+var autoprefixer = require('gulp-autoprefixer');
 var plugins = require('gulp-load-plugins')(); // Load all gulp plugins
                                               // automatically and attach
                                               // them to the `plugins` object
@@ -136,6 +137,14 @@ gulp.task('lint:js', function () {
       .pipe(plugins.jshint.reporter('fail'));
 });
 
+gulp.task('default', function () {
+    return gulp.src('css/main.css')
+        .pipe(autoprefixer({
+            browsers: ['last 2 versions'],
+            cascade: false
+        }))
+        .pipe(gulp.dest('dist'));
+});
 
 // ---------------------------------------------------------------------
 // | Main tasks                                                        |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "del": "^1.1.1",
     "glob": "^4.4.1",
     "gulp": "^3.8.11",
+    "gulp-autoprefixer": "^2.1.0",
     "gulp-header": "^1.2.2",
     "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.2",


### PR DESCRIPTION
Autoprefixer will help keep the CSS cleaner and free of unnecessary/outdated vendor prefixes