### PR TITLE
Simplify analytics snippet using `async` & `defer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### HEAD
+
+* Simplify the Google Analytics snippet using `async` & `defer` ([#1660](https://github.com/h5bp/html5-boilerplate/pull/1660#issuecomment-89285678)).
+
 ### 5.3.0 (January 12, 2016)
 
 * Update jQuery to `v1.12.0`.

--- a/dist/index.html
+++ b/dist/index.html
@@ -27,14 +27,11 @@
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>
 
-        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
         <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='https://www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+            ga('create','UA-XXXXX-Y','auto');ga('send','pageview')
         </script>
+        <script src="https://www.google-analytics.com/analytics.js" async defer></script>
     </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -27,14 +27,11 @@
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>
 
-        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
         <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='https://www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-XXXXX-X','auto');ga('send','pageview');
+            window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+            ga('create','UA-XXXXX-Y','auto');ga('send','pageview')
         </script>
+        <script src="https://www.google-analytics.com/analytics.js" async defer></script>
     </body>
 </html>


### PR DESCRIPTION
With this snippet, modern browsers use `async`, older browsers (i.e. IE8 & IE9) use `defer`.

IE8 and IE9 lack `async` support but they have a broken implementation of `defer`. However, the brokenness doesn’t apply in this scenario since no scripts depend on GA in the way jQuery UI depends on jQuery. `async` is also not supported by the Android 2.3 browser, but that browser does have a preload scanner to make up for it.

Once we drop support for IE8 and IE9, the `defer` attribute can be omitted.

The only downside is that the snippet is not a pure JavaScript solution anymore, meaning it cannot be moved or concatenated into a `.js` file. On the other hand, no one seemed to be doing that anyway; everyone just inlines the snippet into the HTML.

Ref. https://github.com/h5bp/html5-boilerplate/pull/1660#issuecomment-89285678