### PR TITLE
Add Node.js v4 stable to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ language: node_js
 node_js:
   - "iojs"
   - "0.12"
+  - "4"
 
 script:
   - curl -sSLo travis_after_all.py https://raw.github.com/dmakhno/travis_after_all/master/travis_after_all.py


### PR DESCRIPTION
NodeJS v4 was just released [NodeJS v4 announcement](https://nodejs.org/en/blog/release/v4.0.0/). This updates the CI build script to accommodate the release. It should be "4", not "4.0". Node will surely get a lot of minor updates before it goes LTS and html5-boilerplate should test on the latest of them.