### PR TITLE
Change jQuery CDN to a China-safe option

### DIFF
--- a/dist/doc/faq.md
+++ b/dist/doc/faq.md
@@ -3,8 +3,6 @@ table of contents](TOC.md)
 
 # Frequently asked questions
 
-* [Why don't you automatically load the latest version of jQuery from the Google
-  CDN?](#why-dont-you-automatically-load-the-latest-version-of-jquery-from-the-google-cdn)
 * [Why is the Google Analytics code at the bottom? Google recommends it be
   placed in the `<head>`.](#why-is-the-google-analytics-code-at-the-bottom-google-recommends-it-be-placed-in-the-head)
 * [How can I integrate Bootstrap with HTML5
@@ -16,20 +14,6 @@ table of contents](TOC.md)
 
 --
 
-### Why don't you automatically load the latest version of jQuery from the Google CDN?
-
-The [file](https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js) to which
-the Google [CDN](https://en.wikipedia.org/wiki/Content_delivery_network) points
-to is [no longer updated and will stay locked at version `1.11.1` in order to
-prevent inadvertent web
-breakage](http://blog.jquery.com/2014/07/03/dont-use-jquery-latest-js/).
-
-In general, version updating should be an intentional decision! You shouldn't
-include a URL that will always point to the latest version, as that version:
-
- * may not be compatible with the existing plugins/code on the site
- * will have a very short cache time compare to the specific version,
-   which means that users won't get the benefits of long-term caching
 
 ### Why is the Google Analytics code at the bottom? Google recommends it be placed in the `<head>`.
 

--- a/dist/doc/html.md
+++ b/dist/doc/html.md
@@ -176,27 +176,23 @@ The main content area of the boilerplate includes a prompt to install an up to
 date browser for users of IE 6/7. If you intended to support IE 6/7, then you
 should remove the snippet of code.
 
-### Google CDN for jQuery
+### jQuery CDN for jQuery
 
-The Google CDN version of the jQuery JavaScript library is referenced towards
-the bottom of the page using a protocol-independent path (read more about this
-in the [FAQ](faq.md)). A local fallback of jQuery is included for rare instances
+The jQuery CDN version of the jQuery JavaScript library is referenced towards
+the bottom of the page. A local fallback of jQuery is included for rare instances
 when the CDN version might not be available, and to facilitate offline
 development.
 
-The Google CDN version is chosen over other [potential candidates (like the
-jQuery CDN](https://jquery.com/download/#using-jquery-with-a-cdn)) because
-it's fast in absolute terms and it has the best overall
-[penetration](http://httparchive.org/trends.php#perGlibs) which increases the
-odds of having a copy of the library in your user's browser cache.
+The jQuery CDN version was chosen over other potential candidates ([like Google's Hosted Libraries](https://developers.google.com/speed/libraries/)) because
+it's fast ([comparable or faster than Google by some measures](https://www.cdnperf.com/#jsdelivr,cdnjs,google,yandex,microsoft,jquery,bootstrapcdn/https/90)) and, (unlike Google's CDN) is available to China's hundreds of millions of internet users.  For many years we [chose](https://github.com/h5bp/html5-boilerplate/issues/1191) the Google Hosted version over the jQuery CDN because it was available over HTTPS (the jQuery CDN was not,) and it offered a better chance of hitting the cache lottery owing to the popularity of the Google CDN. The first issue is no longer valid and the second is far outweighed by being able to serve jQuery to Chinese users. 
 
-While the Google CDN is a strong default solution your site or application may
+While the jQuery CDN is a strong default solution your site or application may
 require a different configuration. Testing your site with services like
 [WebPageTest](https://www.webpagetest.org/) and browser tools like
 [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) or
 [YSlow](https://developer.yahoo.com/yslow/) will help you examine the real
 world performance of your site and can show where you can optimize your specific
-site or application.
+site or application. 
 
 
 ### Google Universal Analytics Tracking Code

--- a/dist/index.html
+++ b/dist/index.html
@@ -22,7 +22,7 @@
         <!-- Add your site or application content here -->
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+        <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.3.min.js"><\/script>')</script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>

--- a/src/doc/faq.md
+++ b/src/doc/faq.md
@@ -3,8 +3,6 @@ table of contents](TOC.md)
 
 # Frequently asked questions
 
-* [Why don't you automatically load the latest version of jQuery from the Google
-  CDN?](#why-dont-you-automatically-load-the-latest-version-of-jquery-from-the-google-cdn)
 * [Why is the Google Analytics code at the bottom? Google recommends it be
   placed in the `<head>`.](#why-is-the-google-analytics-code-at-the-bottom-google-recommends-it-be-placed-in-the-head)
 * [How can I integrate Bootstrap with HTML5
@@ -16,20 +14,6 @@ table of contents](TOC.md)
 
 --
 
-### Why don't you automatically load the latest version of jQuery from the Google CDN?
-
-The [file](https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js) to which
-the Google [CDN](https://en.wikipedia.org/wiki/Content_delivery_network) points
-to is [no longer updated and will stay locked at version `1.11.1` in order to
-prevent inadvertent web
-breakage](http://blog.jquery.com/2014/07/03/dont-use-jquery-latest-js/).
-
-In general, version updating should be an intentional decision! You shouldn't
-include a URL that will always point to the latest version, as that version:
-
- * may not be compatible with the existing plugins/code on the site
- * will have a very short cache time compare to the specific version,
-   which means that users won't get the benefits of long-term caching
 
 ### Why is the Google Analytics code at the bottom? Google recommends it be placed in the `<head>`.
 

--- a/src/doc/html.md
+++ b/src/doc/html.md
@@ -176,27 +176,23 @@ The main content area of the boilerplate includes a prompt to install an up to
 date browser for users of IE 6/7. If you intended to support IE 6/7, then you
 should remove the snippet of code.
 
-### Google CDN for jQuery
+### jQuery CDN for jQuery
 
-The Google CDN version of the jQuery JavaScript library is referenced towards
-the bottom of the page using a protocol-independent path (read more about this
-in the [FAQ](faq.md)). A local fallback of jQuery is included for rare instances
+The jQuery CDN version of the jQuery JavaScript library is referenced towards
+the bottom of the page. A local fallback of jQuery is included for rare instances
 when the CDN version might not be available, and to facilitate offline
 development.
 
-The Google CDN version is chosen over other [potential candidates (like the
-jQuery CDN](https://jquery.com/download/#using-jquery-with-a-cdn)) because
-it's fast in absolute terms and it has the best overall
-[penetration](http://httparchive.org/trends.php#perGlibs) which increases the
-odds of having a copy of the library in your user's browser cache.
+The jQuery CDN version was chosen over other potential candidates ([like Google's Hosted Libraries](https://developers.google.com/speed/libraries/)) because
+it's fast ([comparable or faster than Google by some measures](https://www.cdnperf.com/#jsdelivr,cdnjs,google,yandex,microsoft,jquery,bootstrapcdn/https/90)) and, (unlike Google's CDN) is available to China's hundreds of millions of internet users.  For many years we [chose](https://github.com/h5bp/html5-boilerplate/issues/1191) the Google Hosted version over the jQuery CDN because it was available over HTTPS (the jQuery CDN was not,) and it offered a better chance of hitting the cache lottery owing to the popularity of the Google CDN. The first issue is no longer valid and the second is far outweighed by being able to serve jQuery to Chinese users. 
 
-While the Google CDN is a strong default solution your site or application may
+While the jQuery CDN is a strong default solution your site or application may
 require a different configuration. Testing your site with services like
 [WebPageTest](https://www.webpagetest.org/) and browser tools like
 [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) or
 [YSlow](https://developer.yahoo.com/yslow/) will help you examine the real
 world performance of your site and can show where you can optimize your specific
-site or application.
+site or application. 
 
 
 ### Google Universal Analytics Tracking Code

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
         <!-- Add your site or application content here -->
         <p>Hello world! This is HTML5 Boilerplate.</p>
 
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/{{JQUERY_VERSION}}/jquery.min.js"></script>
+        <script src="https://code.jquery.com/jquery-{{JQUERY_VERSION}}.min.js"></script>
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-{{JQUERY_VERSION}}.min.js"><\/script>')</script>
         <script src="js/plugins.js"></script>
         <script src="js/main.js"></script>

--- a/test/file_content.js
+++ b/test/file_content.js
@@ -58,7 +58,7 @@ function runTests() {
         });
 
         it('"index.html" should contain the correct jQuery version in the CDN URL', function (done) {
-            var string = 'ajax.googleapis.com/ajax/libs/jquery/' + pkg.devDependencies.jquery + '/jquery.min.js';
+            var string = 'code.jquery.com/jquery-' + pkg.devDependencies.jquery + '.min.js';
             checkString(path.resolve(dir, 'index.html'), string, done);
         });
 


### PR DESCRIPTION
Fixes: #1737

China, with with more web users than there are people in the US, blocks googleaplis.com. We really ought to put the "WORLD" back in World Wide Web with a China-friendly option for jQuery.
