### PR TITLE
Tell users that IE 8 and 9 are outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### HEAD
 
+* Tell users that IE 8 and 9 are outdated
+  ([#1747](https://github.com/h5bp/html5-boilerplate/issues/1747)).
 * Removed IE8 Support (upgrades jQuery and normalize.css to latest)
   ([#1524](https://github.com/h5bp/html5-boilerplate/issues/1524)).
 * Fix print styles for Internet Explorer 11

--- a/dist/index.html
+++ b/dist/index.html
@@ -15,7 +15,7 @@
         <script src="js/vendor/modernizr-2.8.3.min.js"></script>
     </head>
     <body>
-        <!--[if lt IE 8]>
+        <!--[if lte IE 9]>
             <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
         <![endif]-->
 

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
         <script src="js/vendor/modernizr-2.8.3.min.js"></script>
     </head>
     <body>
-        <!--[if lt IE 8]>
+        <!--[if lte IE 9]>
             <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
         <![endif]-->
 


### PR DESCRIPTION
I think [this is a good idea](https://github.com/h5bp/html5-boilerplate/issues/1747), so here's a PR. 

To be clear, this isn't dropping support for IE 8 and 9. This is simply informing users that their older browsers are outdated. This will hopefully promote an increased rate of browser upgrades so that we can eventually drop support once usage falls below whatever threshold we've established.