### PR TITLE
Fix print styles for Internet Explorer 11

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -213,7 +213,10 @@ textarea {
     *:before,
     *:after,
     *:first-letter,
-    *:first-line {
+    p:first-line,
+    div:first-line,
+    blockquote:first-line,
+    li:first-line {
         background: transparent !important;
         color: #000 !important; /* Black prints faster:
                                    http://www.sanbeiji.com/archives/953 */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -205,7 +205,10 @@ textarea {
     *:before,
     *:after,
     *:first-letter,
-    *:first-line {
+    p:first-line,
+    div:first-line,
+    blockquote:first-line,
+    li:first-line {
         background: transparent !important;
         color: #000 !important; /* Black prints faster:
                                    http://www.sanbeiji.com/archives/953 */


### PR DESCRIPTION
*:first-line pseudo-selector freezes window with print preview in IE 11 (tested on Windows 7 with IE 11.0.9600.17420 and 11.0.9600.18204, Windows 8.1 with IE 11.0.9600.16663, Windows 10 with IE 11.63.10586.0)

To reproduce just open: http://demo.html5boilerplate.com/ or /dist/index.html and select Print > Print preview...