### PR TITLE
Change license format to SPDX format

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,7 @@
     }
   },
   "homepage": "https://html5boilerplate.com/",
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/h5bp/html5-boilerplate/blob/master/LICENSE.txt"
-  },
+  "license": "MIT",
   "name": "html5-boilerplate",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The old license style (`license.type` and `license.url`) is [deprecated by NPM](https://docs.npmjs.com/files/package.json#license). Using [SPDX format](https://spdx.org/licenses/MIT.html) instead