### PR TITLE
Include Segment Snippet alongside GA snippet

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,5 +33,12 @@
             ga('create','UA-XXXXX-Y','auto');ga('send','pageview')
         </script>
         <script src="https://www.google-analytics.com/analytics.js" async defer></script>
+        <!-- Segment: change YOUR_WRITE_KEY to be your Segment Project's write key. -->
+        <script type="text/javascript">
+          !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
+          analytics.load("YOUR_WRITE_KEY");
+          analytics.page();
+          }}();
+        </script>
     </body>
 </html>


### PR DESCRIPTION
This adds the [Segment](https://segment.com/docs/libraries/analytics.js) snippet alongside the Google Analytics snippet. This is better because Segments allows you to send data to multiple analytics tools, including Google Analytics, without having to add any other scripts to the page.