### PR TITLE
Added theme-color meta tags and OG meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Choose one of the following options:
   errors in older browsers.
 * "Delete-key friendly." Easy to strip out parts you don't need.
 * Extensive inline and accompanying documentation.
-
+* Open Graph Meta tags. Now boost your social media presence. [NEW]
+* Color metas make mobile browser toolbar to match your website color scheme. [NEW]
 
 ## Browser support
 

--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,12 @@
         <!-- iOS Safari -->
         <meta name="apple-mobile-web-app-status-bar-style" content="#101524">
         
+        <!-- Open Graph Protocol - Decide how your page should display on Facebook and other social media -->
+        <meta property="og:title" content="your jaw-dropping title here" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="you can either use your meta or use sexy and entertaining copy here" />
+        <meta property="og:image" content="a high quality image here" />
+        
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
         <!-- Place favicon.ico in the root directory -->
         

--- a/src/index.html
+++ b/src/index.html
@@ -6,10 +6,19 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-
+        
+        <!-- theme-color meta tag to set the toolbar color in mobile broswer -->
+        
+        <!-- Chrome, Firefox OS, Opera and Vivaldi -->
+        <meta name="theme-color" content="#101524">
+        <!-- Windows Phone -->
+        <meta name="msapplication-navbutton-color" content="#101524">
+        <!-- iOS Safari -->
+        <meta name="apple-mobile-web-app-status-bar-style" content="#101524">
+        
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
         <!-- Place favicon.ico in the root directory -->
-
+        
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">
         <script src="js/vendor/modernizr-2.8.3.min.js"></script>


### PR DESCRIPTION
Hello devs,

I'm very excited 😍 as this is my first pull request on GitHub. I have added two fancy yet needed snippet in my pull request.

Let's discuss - 

#### 1. `theme-color` meta tag

According to Google Developer site - 

> Chrome, Firefox OS, Safari, Internet Explorer and Opera Coast allow you to define colors for elements of the browser

So I thought, why not we (h5bp) should provide this to our users. I know this is a fancy feature, but we all are here to provide latest and best.

##### Official docs 

[Google Developers](https://developers.google.com/web/fundamentals/design-and-ui/browser-customization/theme-color?hl=en)

#### 1. `og` meta tag

According to Open Graph Protocol site - 

> The Open Graph protocol enables any web page to become a rich object in a social graph.

When I downloaded h5bp at that time I presumed that I will get a social-friendly blueprint, and frankly I disappointed a bit. We should provide our users a social-friendly structure. So, I decided to add OG meta tags.

The benefits of these tags are that you can control how your website or app will look and whether it shows contents that convey your message when someone shares on social media platform such as Facebook, Twitter etc. The best part is that many social media follow OG Protocol and in case if you miss some specific site's sharing guideline then they can make use of OG meta tags.

##### Official docs 

[Open Graph Protocol](http://ogp.me/)

Excited to discuss! 😊