### PR TITLE
Fix confusing apple touch icon comment

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
-        <!-- Place favicon.ico in the root directory -->
+
+        <!-- Place favicon.ico in the root directory. You don't need the link element -->
 
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">


### PR DESCRIPTION
In reference to issue #1783 

As said my @roblarsen, the existing favicon related comment is poor and needs clarity.