### PR TITLE
Add common large file format pattern matches to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,14 @@
 # https://github.com/github/linguist#using-gitattributes
 
 dist/.htaccess linguist-vendored
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Git Large File Storage common large file matching patternss
+# https://git-lfs.github.com/
+
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.ai filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.doc filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Specifies patterns for matching files which can be stored using Git
Large File Storage to reduce workflow overhead. The default files are
binary, but this is not mandatory for any given file.