### PR TITLE
Remove print img max-width: 100%. 

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -256,10 +256,6 @@ textarea {
         page-break-inside: avoid;
     }
 
-    img {
-        max-width: 100% !important;
-    }
-
     p,
     h2,
     h3 {


### PR DESCRIPTION
Following the lead of Twitter Bootstrap (see: https://github.com/twbs/bootstrap/pull/19000), remove the print media query that sets a max-width of 100% to images. This code was meant to prevent images from being cut off in print, but has a side effect of causing map tiles to disappear when printing medium-to-large maps (e.g., with Google Maps).

For reference, this style was added to H5BP in https://github.com/h5bp/html5-boilerplate/commit/b2faa1fc3cff20568848c98e9a51ecda61f3bf73

Fixes #1741