### PR TITLE
Set referrer policy to enable Referer headers on HTTPS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="referrer" value="origin-when-cross-origin" />
 
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
         <!-- Place favicon.ico in the root directory -->


### PR DESCRIPTION
HTTPS served websites default to a Referrer Policy of `no-referrer-when-downgrade`, meaning no `Referer` header is sent at all when following a link to a non-HTTPS URL (see [specs][1]). This hurts analytics on the referred website and could hurt any claim of traffic generation from the referring site. It is then [recommended][2] to just use `origin-when-cross-origin` to send a stripped URL (no path, no queries) in `Referer` headers to cross-origin requests (full URLs are still used for same-origin). See more details in the [specs][3].

[1]: https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer-when-downgrade 
[2]: https://https.cio.gov/faq/#how-can-an-https-site-keep-sending-referrer-information-to-linked-http-sites?
[3]: https://www.w3.org/TR/referrer-policy/#referrer-policy-origin-when-cross-origin