### PR TITLE
Reference sitemap.xml from robots.txt file

### DIFF
--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -362,10 +362,17 @@ You can read about this useful element and more techniques in
 
 ### Direct search spiders to your sitemap
 
-[Learn how to make a sitemap](http://www.sitemaps.org/protocol.html)
+After creating a [sitemap](http://www.sitemaps.org/protocol.html)
 
-```html
-<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+Submit it to search engine tool:
+* [Google](https://www.google.com/webmasters/tools/sitemap-list)
+* [Bing](http://www.bing.com/toolbox/webmaster)
+* [Yandex](https://webmaster.yandex.com/)
+* [Baidu](http://zhanzhang.baidu.com/)
+OR
+Insert the following line anywhere in your robots.txt file, specifying the path to your sitemap:
+```
+Sitemap: http://example.com/sitemap_location.xml
 ```
 
 ### Hide pages from search engines


### PR DESCRIPTION
Replaced urban legend about referencing robots.txt file for with an actually working and suggested by all major search engines method.

See:
[Google](https://support.google.com/webmasters/answer/183668?hl=en#addsitemap)
[Bing](https://www.bing.com/webmaster/help/how-to-submit-sitemaps-82a15bd4)
[Yandex](https://yandex.com/support/webmaster/indexing-options/sitemap.xml#notify-about)

ref: https://github.com/h5bp/html5-boilerplate/issues/1895, https://github.com/LotusTM/Kotsu/issues/88