### PR TITLE
Improve ::selection documentation which became confusing after c7057be

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -18,7 +18,9 @@ html {
  * Remove text-shadow in selection highlight:
  * https://twitter.com/miketaylr/status/12228805301
  *
- * These selection rule sets have to be separate.
+ * Vendor-prefixed and regular ::selection selectors cannot be combined:
+ * https://stackoverflow.com/a/16982510/7133471
+ *
  * Customize the background color to match your design.
  */
 


### PR DESCRIPTION
After Autoprefixer was added a comment explaining that the vendor prefixed
`::-moz-selection` and the default `::selection` can't be combined became
obsolete. I (with the help of @roblarsen) rephrased the comment to be more
general and so that it still makes sense in the dist css file. A stackoverflow link
explains why vendor prefixed selectors can't be combined with other selectors.

Fixes #1953