### PR TITLE
Remove link to ySlow

### DIFF
--- a/src/doc/html.md
+++ b/src/doc/html.md
@@ -209,8 +209,7 @@ being able to serve jQuery to Chinese users.
 While the jQuery CDN is a strong default solution your site or application may
 require a different configuration. Testing your site with services like
 [WebPageTest](https://www.webpagetest.org/) and browser tools like
-[PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) or
-[YSlow](https://developer.yahoo.com/yslow/) will help you examine the real
+[PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) will help you examine the real
 world performance of your site and can show where you can optimize your specific
 site or application.
 


### PR DESCRIPTION
Yahoo's YSlow is (sadly) no longer actively maintained. The browser extensions don't work anymore and the main repo hasn't been updated for nearly four years. I suggest to remove the http://developer.yahoo.com/yslow/ link.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



