### PR TITLE
Fix ::first-letter in print style causing incorrect rendering in Chrome

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -223,15 +223,7 @@ textarea {
 @media print {
     *,
     *:before,
-    *:after,
-    p:first-letter,
-    div:first-letter,
-    blockquote:first-letter,
-    li:first-letter,
-    p:first-line,
-    div:first-line,
-    blockquote:first-line,
-    li:first-line {
+    *:after {
         background: transparent !important;
         color: #000 !important; /* Black prints faster:
                                    http://www.sanbeiji.com/archives/953 */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -213,15 +213,7 @@ textarea {
 @media print {
     *,
     *:before,
-    *:after,
-    p:first-letter,
-    div:first-letter,
-    blockquote:first-letter,
-    li:first-letter,
-    p:first-line,
-    div:first-line,
-    blockquote:first-line,
-    li:first-line {
+    *:after {
         background: transparent !important;
         color: #000 !important; /* Black prints faster:
                                    http://www.sanbeiji.com/archives/953 */


### PR DESCRIPTION
Chrome currently has a bug (when printing) that results in
::first-letter being vertically misaligned under certain (seemingly
unrelated) conditions. This PR fixes issue by removing the CSS that
causes the issue.

Thanks @patrickhlauke for the heads-up on this. (https://github.com/h5bp/html5-boilerplate/issues/1961)

For reference; the Chrome issue is logged at: https://bugs.chromium.org/p/chromium/issues/detail?id=739800


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



