### PR TITLE
Remove 'Chrome Web Store app section'

### DIFF
--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -22,17 +22,6 @@ not everything fits with everyone's needs.
 
 ## App Stores
 
-### Install a Chrome Web Store app
-
-Users can install a Chrome app directly from your website, as long as
-the app and site have been associated via Google's Webmaster Tools.
-Read more on [Chrome Web Store's Inline Installation
-docs](https://developer.chrome.com/webstore/inline_installation).
-
-```html
-<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/APP_ID">
-```
-
 ### Smart App Banners in iOS 6+ Safari
 
 Stop bothering everyone with gross modals advertising your entry in the


### PR DESCRIPTION
Chrome Web Store are no longer accepting submissions for web apps (Windows, Mac or Linux) so this section is no longer needed. Users can use W3C Manifest file instead to allow for users to install their webapps.

> As of 21 November 2016, all newly published packaged or hosted apps are restricted to Chrome OS, and are not available to users on Windows, Mac or Linux. Existing apps will continue to be available on all major platforms and will continue to receive updates
REF: https://blog.chromium.org/2016/08/from-chrome-apps-to-web.html

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



