### PR TITLE
Fix Bug: .visuallyhidden on macOS VO

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -132,7 +132,7 @@ textarea {
     clip: rect(0 0 0 0);
     clip-path: inset(50%);
     height: 1px;
-    margin: -1px;
+    margin: 0;
     overflow: hidden;
     padding: 0;
     position: absolute;


### PR DESCRIPTION
This PR solves [issue 1985: macOS - VoiceOver / Chrome announcing visually hidden text out of order](https://github.com/h5bp/html5-boilerplate/issues/1985)

By removing the negative margin, and setting it to `margin: 0;`, the issue is resolved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



