### PR TITLE
Re-adding position to .visuallyhidden class

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -135,6 +135,7 @@ textarea {
     margin: -1px;
     overflow: hidden;
     padding: 0;
+    position: absolute;
     width: 1px;
     white-space: nowrap; /* 1 */
 }


### PR DESCRIPTION
Without `position: absolute` the `.visuallyhidden` element adds space to the container.

Demo: https://codepen.io/svinkle/pen/LjQJbZ

Thread: https://github.com/h5bp/html5-boilerplate/issues/1985#issuecomment-323485667



