### PR TITLE
Upgrading to babel-preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "apache-server-configs": "2.15.0",
     "archiver": "^2.1.0",
     "babel-core": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "del": "^3.0.0",
     "glob": "^7.1.2",
@@ -33,7 +33,7 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "env"
     ]
   },
   "h5bp-configs": {
@@ -61,8 +61,8 @@
     "modernizr-config.json",
     "README.md"
   ],
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/h5bp/html5-boilerplate.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/h5bp/html5-boilerplate.git"
   }
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This pull request handles upgrading from babel-preset-es2015 which fixes the issue when running `npm install`.
```
npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
```
