### PR TITLE
Remove info about Flash in Metro mode IE10 (no longer applicable)

### DIFF
--- a/dist/doc/extend.md
+++ b/dist/doc/extend.md
@@ -215,28 +215,6 @@ $(function(){
 
 ## Internet Explorer
 
-### Prompt users to switch to "Desktop Mode" in IE10 Metro
-
-IE10 does not support plugins, such as Flash, in Metro mode. If
-your site requires plugins, you can let users know that via the
-`x-ua-compatible` meta element, which will prompt them to switch
-to Desktop Mode.
-
-```html
-<meta http-equiv="x-ua-compatible" content="requiresActiveX=true">
-```
-
-Here's what it looks like alongside H5BP's default `x-ua-compatible`
-values:
-
-```html
-<meta http-equiv="x-ua-compatible" content="ie=edge,requiresActiveX=true">
-```
-
-You can find more information in [Microsoft's IEBlog post about prompting for
-plugin use in IE10 Metro
-Mode](https://blogs.msdn.microsoft.com/ie/2012/01/31/web-sites-and-a-plug-in-free-web/).
-
 ### IE Pinned Sites (IE9+)
 
 Enabling your application for pinning will allow IE9 users to add it to their

--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -215,28 +215,6 @@ $(function(){
 
 ## Internet Explorer
 
-### Prompt users to switch to "Desktop Mode" in IE10 Metro
-
-IE10 does not support plugins, such as Flash, in Metro mode. If
-your site requires plugins, you can let users know that via the
-`x-ua-compatible` meta element, which will prompt them to switch
-to Desktop Mode.
-
-```html
-<meta http-equiv="x-ua-compatible" content="requiresActiveX=true">
-```
-
-Here's what it looks like alongside H5BP's default `x-ua-compatible`
-values:
-
-```html
-<meta http-equiv="x-ua-compatible" content="ie=edge,requiresActiveX=true">
-```
-
-You can find more information in [Microsoft's IEBlog post about prompting for
-plugin use in IE10 Metro
-Mode](https://blogs.msdn.microsoft.com/ie/2012/01/31/web-sites-and-a-plug-in-free-web/).
-
 ### IE Pinned Sites (IE9+)
 
 Enabling your application for pinning will allow IE9 users to add it to their


### PR DESCRIPTION
This was addressed nearly 5 years ago:
https://blogs.msdn.microsoft.com/ie/2013/03/11/flash-in-windows-8/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



