### PR TITLE
Removes "display": "standalone" from manifest

### DIFF
--- a/dist/site.webmanifest
+++ b/dist/site.webmanifest
@@ -8,6 +8,5 @@
   }],
   "start_url": "/?utm_source=homescreen",
   "background_color": "#fafafa",
-  "theme_color": "#fafafa",
-  "display": "standalone"
+  "theme_color": "#fafafa"
 }

--- a/src/site.webmanifest
+++ b/src/site.webmanifest
@@ -8,6 +8,5 @@
   }],
   "start_url": "/?utm_source=homescreen",
   "background_color": "#fafafa",
-  "theme_color": "#fafafa",
-  "display": "standalone"
+  "theme_color": "#fafafa"
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This change removes the "display": "standalone" from manifest. It is better to default to the browsers default as not all websites using manifests are PWAs intended to be run fullscreen with no navigation bar.

This fixes: #2090 - Thanks @philwareham for the heads-up on this one!