### PR TITLE
Removed link to #404html

### DIFF
--- a/src/doc/html.md
+++ b/src/doc/html.md
@@ -7,7 +7,7 @@ By default, HTML5 Boilerplate provides two `html` pages:
 
 * [`index.html`](#indexhtml) - a default HTML skeleton that should form the
   basis of all pages on your website
-* [`404.html`](#404html) - a placeholder 404 error page
+* `404.html` - a placeholder 404 error page
 
 
 ## `index.html`


### PR DESCRIPTION
I've removed link to #404html section of the page, since there is on section for 404 page and in IDE I'm getting "Cannot resolve anchor #404html" warning. I hope that it makes sense.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Pull requests should be thought of as a conversation. There will be some back and forth when trying to get code merged into this or any other project. With all but the simplest changes you can and should expect that the maintainers of the project will request changes to your code. Please be aware of that and check in after you open your PR in order to get your code merged in cleanly. 

Thanks!
