### PR TITLE
remove instances of shrink-to-fit=no

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title></title>
   <meta name="description" content="">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="manifest" href="site.webmanifest">
   <link rel="apple-touch-icon" href="icon.png">

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title></title>
   <meta name="description" content="">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="manifest" href="site.webmanifest">
   <link rel="apple-touch-icon" href="icon.png">


### PR DESCRIPTION
closes #2102

Per my findings, the need for it as a default was rectified with the release of iOS 9.3, where the viewport no longer shrunk to accommodate overflow, as was introduced in iOS 9.

### Types of changes
Removal of meta data no longer necessary.

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. **N/A** (wasn't mentioned in the section on viewport)
- [x] I have updated the documentation accordingly.  **N/A**
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes. **N/A**
- [x] All new and existing tests passed. **N/A**