### PR TITLE
Added Gitpod Support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+image:
+  file: Dockerfile
+  context: .
+ports:
+- port: 80
+- port: 443
+tasks:
+- command: chromium

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": true
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM gitpod/workspace-full-vnc
+# add your tools here
+RUN sudo apt-get install chromium
+RUN sudo apt-get install firefox
+# Installing Opera
+RUN wget -qO- https://deb.opera.com/archive.key | sudo apt-key add - && sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
+RUN sudo apt install opera-stable
+#Installing Brave Browser
+RUN curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key --keyring /etc/apt/trusted.gpg.d/brave-browser-release.gpg add -
+RUN sudo sh -c 'echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com `lsb_release -sc` main" >> /etc/apt/sources.list.d/brave.list'
+RUN sudo apt update && sudo apt install brave-browser brave-keyring
+RUN sudo apt update
+#Plus:Installing Visual Studio Code for the brave
+RUN sudo apt install software-properties-common apt-transport-https wget
+RUN wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | sudo apt-key add -
+RUN sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main"
+RUN sudo apt update && sudo apt install code


### PR DESCRIPTION
This pull request adds support for the awesome Gitpod cloud ide...it contains a Dockerfile and the Gitpod config...

The Dockerfile installs into a gitpod environment the major browsers for html5 app testing plus the awesome Visual Studio Code for the devs who not like Gitpod's Theia based IDE.
Commit created from a great fan of Docker and Gitpod...
I hope it can be useful!