### PR TITLE
Add License, NPM Download counter and GitHub Stars counter badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # [HTML5 Boilerplate](https://html5boilerplate.com/)
 
+[![LICENSE](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/h5bp/html5-boilerplate/blob/master/LICENSE.txt)
 [![Build Status](https://travis-ci.org/h5bp/html5-boilerplate.svg)](https://travis-ci.org/h5bp/html5-boilerplate)
 [![devDependency Status](https://david-dm.org/h5bp/html5-boilerplate/dev-status.svg)](https://david-dm.org/h5bp/html5-boilerplate#info=devDependencies)
+[![NPM Downloads](https://img.shields.io/npm/dt/html5-boilerplate.svg)](https://www.npmjs.com/package/html5-boilerplate)
+[![github-stars-image](https://img.shields.io/github/stars/h5bp/html5-boilerplate.svg?label=github%20stars)](https://github.com/h5bp/html5-boilerplate)
 
 HTML5 Boilerplate is a professional front-end template for building
 fast, robust, and adaptable web apps or sites.


### PR DESCRIPTION
README badges looks good. HTML5 Boilerplate is a popular project and showing the number of NPM downloads and GitHub stars on the README is a good way to show this off.