### PR TITLE
fix broken links in TOC

### DIFF
--- a/dist/doc/css.md
+++ b/dist/doc/css.md
@@ -6,10 +6,7 @@ table of contents](TOC.md)
 HTML5 Boilerplate's CSS includes:
 
 * [Normalize.css](#normalizecss)
-* [Useful defaults](#useful-defaults)
-* [Common helpers](#common-helpers)
-* [Placeholder media queries](#media-queries)
-* [Print styles](#print-styles)
+* [main.css](#maincss)
 
 This starting CSS does not rely on the presence of
 [conditional class names](https://www.paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/),

--- a/src/doc/css.md
+++ b/src/doc/css.md
@@ -6,10 +6,7 @@ table of contents](TOC.md)
 HTML5 Boilerplate's CSS includes:
 
 * [Normalize.css](#normalizecss)
-* [Useful defaults](#useful-defaults)
-* [Common helpers](#common-helpers)
-* [Placeholder media queries](#media-queries)
-* [Print styles](#print-styles)
+* [main.css](#maincss)
 
 This starting CSS does not rely on the presence of
 [conditional class names](https://www.paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/),


### PR DESCRIPTION
This fixes the broken links in the CSS docs.
Thanks for spotting this @PeteSchuster  !