### PR TITLE
bump lowest supported version of node to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "strip-json-comments": "^2.0.1"
   },
   "engines": {
-    "node": ">=6",
+    "node": ">=8",
     "npm": ">=3"
   },
   "babel": {


### PR DESCRIPTION
previous versions are end-of-life.

REF: https://github.com/nodejs/Release
