### PR TITLE
Update links in docs

### DIFF
--- a/dist/404.html
+++ b/dist/404.html
@@ -59,4 +59,4 @@
 </body>
 
 </html>
-<!-- IE needs 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->
+<!-- IE needs 512+ bytes: https://docs.microsoft.com/archive/blogs/ieinternals/friendly-http-error-pages -->

--- a/dist/doc/css.md
+++ b/dist/doc/css.md
@@ -10,7 +10,6 @@ HTML5 Boilerplate's CSS includes:
 
 This starting CSS does not rely on the presence of
 [conditional class names](https://www.paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/),
-[conditional style sheets](https://css-tricks.com/how-to-create-an-ie-only-stylesheet/),
 or [Modernizr](https://modernizr.com/), and it is ready to use no matter what
 your development preferences happen to be.
 

--- a/dist/doc/extend.md
+++ b/dist/doc/extend.md
@@ -25,7 +25,7 @@ not everything fits with everyone's needs.
 ### Smart App Banners in iOS 6+ Safari
 
 Stop bothering everyone with gross modals advertising your entry in the
-App Store. Including the following [meta tag](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html) will unobtrusively give the user the option to download your iOS app, or open it with some data about the user's current state on the website.
+App Store. Including the following [meta tag](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html) will unobtrusively give the user the option to download your iOS app, or open it with some data about the user's current state on the website.
 
 ```html
 <meta name="apple-itunes-app" content="app-id=APP_ID,app-argument=SOME_TEXT">

--- a/dist/doc/html.md
+++ b/dist/doc/html.md
@@ -124,12 +124,12 @@ Starting with version 3 Modernizr can be customized using the [modernizr-config.
 
 If you need to include [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill)
 in your project, you must make sure those load before any other JavaScript. If you're
-using a polyfill CDN service, like [cdn.polyfill.io](https://cdn.polyfill.io/),
+using a polyfill CDN service, like [polyfill.io](https://polyfill.io/),
 just put it before the other scripts in the bottom of the page:
 
 ```html
     <script src="js/vendor/modernizr-3.8.0.min.js"></script>
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.4.1.min.js"><\/script>')</script>
     <script src="js/plugins.js"></script>

--- a/dist/doc/js.md
+++ b/dist/doc/js.md
@@ -18,8 +18,7 @@ other 3rd party scripts for a simple site.
 
 One approach is to put jQuery plugins inside of a `(function($){ ...
 })(jQuery);` closure to make sure they're in the jQuery namespace safety
-blanket. Read more about [jQuery plugin
-authoring](https://learn.jquery.com/plugins/#Getting_Started).
+blanket. Read more about [jQuery plugin authoring](https://learn.jquery.com/plugins/).
 
 By default the `plugins.js` file contains a small script to avoid `console`
 errors in browsers that lack a `console`. The script will make sure that, if

--- a/dist/doc/misc.md
+++ b/dist/doc/misc.md
@@ -151,7 +151,7 @@ The provided file contains three sections:
   * `THANKS` - this is intended to list the group of people that have contributed
   to the website
   * `TECHNOLOGY COLOPHON` - the section lists technologies used to make the website
-  
+
 For more information about `humans.txt`, please see: http://humanstxt.org/
 
 
@@ -170,4 +170,4 @@ By default, the file points to 2 placeholder tile images:
 Notice that IE11 uses the same images when adding a site to the `favorites`.
 
 For more in-depth information about the `browserconfig.xml` file, please
-see [MSDN](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)).
+see [MSDN](https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)).

--- a/src/404.html
+++ b/src/404.html
@@ -59,4 +59,4 @@
 </body>
 
 </html>
-<!-- IE needs 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->
+<!-- IE needs 512+ bytes: https://docs.microsoft.com/archive/blogs/ieinternals/friendly-http-error-pages -->

--- a/src/doc/css.md
+++ b/src/doc/css.md
@@ -10,7 +10,6 @@ HTML5 Boilerplate's CSS includes:
 
 This starting CSS does not rely on the presence of
 [conditional class names](https://www.paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/),
-[conditional style sheets](https://css-tricks.com/how-to-create-an-ie-only-stylesheet/),
 or [Modernizr](https://modernizr.com/), and it is ready to use no matter what
 your development preferences happen to be.
 

--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -25,7 +25,7 @@ not everything fits with everyone's needs.
 ### Smart App Banners in iOS 6+ Safari
 
 Stop bothering everyone with gross modals advertising your entry in the
-App Store. Including the following [meta tag](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html) will unobtrusively give the user the option to download your iOS app, or open it with some data about the user's current state on the website.
+App Store. Including the following [meta tag](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html) will unobtrusively give the user the option to download your iOS app, or open it with some data about the user's current state on the website.
 
 ```html
 <meta name="apple-itunes-app" content="app-id=APP_ID,app-argument=SOME_TEXT">

--- a/src/doc/html.md
+++ b/src/doc/html.md
@@ -124,12 +124,12 @@ Starting with version 3 Modernizr can be customized using the [modernizr-config.
 
 If you need to include [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill)
 in your project, you must make sure those load before any other JavaScript. If you're
-using a polyfill CDN service, like [cdn.polyfill.io](https://cdn.polyfill.io/),
+using a polyfill CDN service, like [polyfill.io](https://polyfill.io/),
 just put it before the other scripts in the bottom of the page:
 
 ```html
     <script src="js/vendor/modernizr-3.8.0.min.js"></script>
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.4.1.min.js"><\/script>')</script>
     <script src="js/plugins.js"></script>

--- a/src/doc/js.md
+++ b/src/doc/js.md
@@ -18,8 +18,7 @@ other 3rd party scripts for a simple site.
 
 One approach is to put jQuery plugins inside of a `(function($){ ...
 })(jQuery);` closure to make sure they're in the jQuery namespace safety
-blanket. Read more about [jQuery plugin
-authoring](https://learn.jquery.com/plugins/#Getting_Started).
+blanket. Read more about [jQuery plugin authoring](https://learn.jquery.com/plugins/).
 
 By default the `plugins.js` file contains a small script to avoid `console`
 errors in browsers that lack a `console`. The script will make sure that, if

--- a/src/doc/misc.md
+++ b/src/doc/misc.md
@@ -151,7 +151,7 @@ The provided file contains three sections:
   * `THANKS` - this is intended to list the group of people that have contributed
   to the website
   * `TECHNOLOGY COLOPHON` - the section lists technologies used to make the website
-  
+
 For more information about `humans.txt`, please see: http://humanstxt.org/
 
 
@@ -170,4 +170,4 @@ By default, the file points to 2 placeholder tile images:
 Notice that IE11 uses the same images when adding a site to the `favorites`.
 
 For more in-depth information about the `browserconfig.xml` file, please
-see [MSDN](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)).
+see [MSDN](https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)).


### PR DESCRIPTION
- The 'Getting Started' section header no longer exists on that jQuery plugins page so I removed.
- cdn.polyfill.io is now just polyfill.io
- update Apple docs URL to prevent a redirect
- Remove CSS Tricks link to IE-only stylesheets as it only applied to IE9 and below which is no longer supported by H5BP or Microsoft
- Microsoft own docs have a rule to not include the country code so that a user gets the docs in their own locale. so a user in UK would go to https://docs.microsoft.com/en-gb/ and a US user would go to https://docs.microsoft.com/en-us/ etc. I suggest we follow their recommendation here.
