### PR TITLE
Fix for w3c title must not be empty rule

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title></title>
+  <title>Hello</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
This pull request fixes w3c validator error - title must not be empty - by defining a default Hello title for the index.html page.