### PR TITLE
Consistent code formatting fix

### DIFF
--- a/dist/doc/html.md
+++ b/dist/doc/html.md
@@ -82,10 +82,10 @@ preview image, URL, and [type](https://ogp.me/#types) (e.g., video, music,
 website, article).
 
 ``` html
-<meta property="og:title" content="" />
-<meta property="og:type" content="" />
-<meta property="og:url" content="" />
-<meta property="og:image" content="" />
+<meta property="og:title" content="">
+<meta property="og:type" content="">
+<meta property="og:url" content="">
+<meta property="og:image" content="">
 ```
 
 In addition to these four attributes there are many more attributes you can use

--- a/dist/doc/misc.md
+++ b/dist/doc/misc.md
@@ -186,11 +186,11 @@ if you're interested. The fields we provide are as follows:
   also define custom scripts for use with your application development. We
   provide three custom scripts that work with Parcel to get you up and running
   quickly with a bundler for your assets and a simple development server.
-  
+
   * `start` builds your site and starts a server
   * `build` builds your `index.html` using Parcel
   * `dev` serves your `index.html` with a simple development server
-  
+
 * `keywords` - an array of keywords used to discover your app in the npm
   registry
 * `author` - defines the author (via `name`, `email` and `url` fields) of a
@@ -201,4 +201,3 @@ if you're interested. The fields we provide are as follows:
 * `devDependencies` - development dependencies for your package. In our case
   it's a single dependency, Parcel, which we use to bundle files and run a
   simple web server.
-  

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,11 +6,11 @@
   <title></title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <meta property="og:title" content="" />
-  <meta property="og:type" content="" />
-  <meta property="og:url" content="" />
-  <meta property="og:image" content="" />
+
+  <meta property="og:title" content="">
+  <meta property="og:type" content="">
+  <meta property="og:url" content="">
+  <meta property="og:image" content="">
 
   <link rel="manifest" href="site.webmanifest">
   <link rel="apple-touch-icon" href="icon.png">
@@ -33,7 +33,7 @@
   <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
   <script>
     window.ga = function () { ga.q.push(arguments) }; ga.q = []; ga.l = +new Date;
-    ga('create', 'UA-XXXXX-Y', 'auto'); ga('set', 'anonymizeIp', true); ga('set','transport','beacon'); ga('send', 'pageview')
+    ga('create', 'UA-XXXXX-Y', 'auto'); ga('set', 'anonymizeIp', true); ga('set', 'transport', 'beacon'); ga('send', 'pageview')
   </script>
   <script src="https://www.google-analytics.com/analytics.js" async></script>
 </body>

--- a/src/doc/html.md
+++ b/src/doc/html.md
@@ -82,10 +82,10 @@ preview image, URL, and [type](https://ogp.me/#types) (e.g., video, music,
 website, article).
 
 ``` html
-<meta property="og:title" content="" />
-<meta property="og:type" content="" />
-<meta property="og:url" content="" />
-<meta property="og:image" content="" />
+<meta property="og:title" content="">
+<meta property="og:type" content="">
+<meta property="og:url" content="">
+<meta property="og:image" content="">
 ```
 
 In addition to these four attributes there are many more attributes you can use

--- a/src/doc/misc.md
+++ b/src/doc/misc.md
@@ -186,11 +186,11 @@ if you're interested. The fields we provide are as follows:
   also define custom scripts for use with your application development. We
   provide three custom scripts that work with Parcel to get you up and running
   quickly with a bundler for your assets and a simple development server.
-  
+
   * `start` builds your site and starts a server
   * `build` builds your `index.html` using Parcel
   * `dev` serves your `index.html` with a simple development server
-  
+
 * `keywords` - an array of keywords used to discover your app in the npm
   registry
 * `author` - defines the author (via `name`, `email` and `url` fields) of a
@@ -201,4 +201,3 @@ if you're interested. The fields we provide are as follows:
 * `devDependencies` - development dependencies for your package. In our case
   it's a single dependency, Parcel, which we use to bundle files and run a
   simple web server.
-  

--- a/src/index.html
+++ b/src/index.html
@@ -6,11 +6,11 @@
   <title></title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <meta property="og:title" content="" />
-  <meta property="og:type" content="" />
-  <meta property="og:url" content="" />
-  <meta property="og:image" content="" />
+
+  <meta property="og:title" content="">
+  <meta property="og:type" content="">
+  <meta property="og:url" content="">
+  <meta property="og:image" content="">
 
   <link rel="manifest" href="site.webmanifest">
   <link rel="apple-touch-icon" href="icon.png">
@@ -33,7 +33,7 @@
   <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
   <script>
     window.ga = function () { ga.q.push(arguments) }; ga.q = []; ga.l = +new Date;
-    ga('create', 'UA-XXXXX-Y', 'auto'); ga('set', 'anonymizeIp', true); ga('set','transport','beacon'); ga('send', 'pageview')
+    ga('create', 'UA-XXXXX-Y', 'auto'); ga('set', 'anonymizeIp', true); ga('set', 'transport', 'beacon'); ga('send', 'pageview')
   </script>
   <script src="https://www.google-analytics.com/analytics.js" async></script>
 </body>


### PR DESCRIPTION
- Removed unneeded self-closing tags from Open Graph meta tags - we don't use them elsewhere
- Add spacing for transport-beacon in Google Analytics for consistency
- remove unneeded whitespace from `misc.md`