### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
https://help.github.com/en/github/managing-security-vulnerabilities/configuring-github-dependabot-security-updates

Dependabot works well in `create-html5-boilerplate`, may be useful here too as for me.