### PR TITLE
fix: Change keywords type from string to string array

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": " ",
   "version": "0.0.1",
   "description": "",
-  "keywords": "",
+  "keywords": [""],
   "license": "",
   "author": "",
   "scripts": {


### PR DESCRIPTION
- Change keywords type from string to string array

Thank you for good project :)
In pkacage.json, the keywords are not string type but string array.

### reference
> https://docs.npmjs.com/files/package.json#keywords
> #### keywords
> Put keywords in it. It’s an array of strings. This helps people discover your package as it’s listed in npm search.

