### PR TITLE
fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      time: "03:00"
-    open-pull-requests-limit: 10
+    versioning-strategy: increase


### PR DESCRIPTION
Right now when a PR is merged it updates the package-lock.json but not the package.json. Ideally it should do both.
We can adjust (fix) that by adding the line 'versioning-strategy: increase' to the dependabot.yml config.
That's what Bootstrap has (https://github.com/twbs/bootstrap/blob/main/.github/dependabot.yml).
Details:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Pull requests should be thought of as a conversation. There will be some back and forth when trying to get code merged into this or any other project. With all but the simplest changes you can and should expect that the maintainers of the project will request changes to your code. Please be aware of that and check in after you open your PR in order to get your code merged in cleanly.

Thanks!
