### PR TITLE
Move humans.txt ToC link from misc to extend doc

### DIFF
--- a/src/doc/extend.md
+++ b/src/doc/extend.md
@@ -17,6 +17,7 @@ everything fits with everyone's needs.
 * [Social Networks](#social-networks)
 * [URLs](#urls)
 * [Web Apps](#web-apps)
+* [humans.txt](#humanstxt)
 * [security.txt](#security.txt)
 
 ## App Stores

--- a/src/doc/misc.md
+++ b/src/doc/misc.md
@@ -7,7 +7,6 @@ table of contents](TOC.md)
 * [.editorconfig](#editorconfig)
 * [Server Configuration](#server-configuration)
 * [robots.txt](#robotstxt)
-* [humans.txt](#humanstxt)
 * [browserconfig.xml](#browserconfigxml)
 * [package.json](#packagejson)
 


### PR DESCRIPTION
Very minor fix to make Table of Contents match the file content after this change: https://github.com/h5bp/html5-boilerplate/commit/be09d9853161d63688f6cf78e28dfe23a383612c

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I don't see a CONTRIBUTING document...am i missing that somewhere?
