### PR TITLE
Alert on attempt to use Topics API

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -39,6 +39,20 @@ potential
 [encoding-related security issue](https://code.google.com/archive/p/doctype-mirror/wikis/ArticleUtf7.wiki)
 in Internet Explorer.
 
+### document.browsingTopics alert
+
+In some cases, a third-party script can collect browsing interest information about users
+using new experimental functionality called Topics API. The first script in the page header
+will alert you if a script is attempting to do this.  The line can be removed if your site
+is turning off Topics API with a Permissions-Policy, running without third-party scripts,
+or if you are using Topics API.
+
+The line can be changed to send an analytics event to check if third-party scripts begin trying
+to use Topics API in production.
+
+For more information, see [Google's Topics API: Rebranding FLoC Without Addressing Key 
+Privacy Issues](https://brave.com/web-standards-at-brave/7-googles-topics-api/)
+
 ### Meta Description
 
 The `description` meta tag provides a short description of the page. In some

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <script>document.browsingTopics=()=>{alert('Topics API called: check third-party scripts.'}</script>
   <title></title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
As multiple third-party scripts might be added to a site during
development, it can be difficult to see when a script is
attempting to use new browser features that might have privacy
consequences.

Consider adding a simple alert so that scripts can be checked and/or
the site Permissions-Policy set before deploying to production.

The "alert" is for development purposes, and could be replaced with
an analytics event if a site wants to monitor attempted use of
Topics API by third parties in production.

Related: https://github.com/h5bp/html5-boilerplate/pull/2459

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **[CONTRIBUTING](https://github.com/h5bp/html5-boilerplate/blob/main/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Pull requests should be thought of as a conversation. There will be some back and forth when trying to get code merged into this or any other project. With all but the simplest changes you can and should expect that the maintainers of the project will request changes to your code. Please be aware of that and check in after you open your PR in order to get your code merged in cleanly.

Thanks!
