### PR TITLE
Minor docs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.0.1 (April 11, 2023)
+## 9.0.1 (April 11, 2024)
 
 - Fixed tests on Windows, adds Windows Testing Action [#3110](https://github.com/h5bp/html5-boilerplate/pull/3110)
 - Add og:image:alt for accessibility [#3066](https://github.com/h5bp/html5-boilerplate/pull/3066)

--- a/dist/robots.txt
+++ b/dist/robots.txt
@@ -1,4 +1,4 @@
-# www.robotstxt.org/
+# https://www.robotstxt.org/
 
 # Allow crawling of all content
 User-agent: *

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -5,7 +5,6 @@ table of contents](TOC.md)
 
 - [.gitignore](#gitignore)
 - [.editorconfig](#editorconfig)
-- [Server Configuration](#server-configuration)
 - [robots.txt](#robotstxt)
 - [package.json](#packagejson)
 

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,4 +1,4 @@
-# www.robotstxt.org/
+# https://www.robotstxt.org/
 
 # Allow crawling of all content
 User-agent: *


### PR DESCRIPTION
## Types of changes

- Fix release date year for recent release on CHANGELOG
- Add https:// to www.robotstxt.org link-  this has advantage of allowing users to Ctrl+click to view site to view more details
- Remove broken `#server-configuration` in-page link (doesn't exist)
