### PR TITLE
Remove JS-conditional classes

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="">
+<html lang="">
 
 <head>
   <meta charset="utf-8">

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -251,7 +251,7 @@ Tool](https://developers.google.com/search/docs/appearance/structured-data). Als
 note that this markup requires to add attributes to your top `html` tag.
 
 ```html
-<html class="no-js" lang="" itemscope itemtype="https://schema.org/Article">
+<html lang="" itemscope itemtype="https://schema.org/Article">
   <head>
 
     <link rel="author" href="">

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -149,6 +149,13 @@ content="telephone=no">`](https://developer.apple.com/library/archive/documentat
   page) by [implementing X-Robots-tag
   headers](https://github.com/h5bp/html5-boilerplate/issues/804).
 
+- Apply JavaScript-dependent CSS styles using [the `scripting` media
+  feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting).
+  Use `@media (scripting: none) { ... }` to target browsers with JavaScript
+  disabled, or `@media (scripting: enabled) { ... }` to target browsers with
+  JavaScript enabled. Using this technique also helps [avoid the
+  FOUC](https://www.paulirish.com/2009/avoiding-the-fouc-v3/).
+
 ## News Feeds
 
 ### RSS

--- a/docs/html.md
+++ b/docs/html.md
@@ -11,13 +11,6 @@ By default, HTML5 Boilerplate provides two `html` pages:
 
 ## `index.html`
 
-### The `no-js` Class
-
-The `no-js` class is provided in order to allow you to more easily and
-explicitly add custom styles based on whether JavaScript is disabled (`.no-js`)
-or enabled (`.js`). Using this technique also helps [avoid the
-FOUC](https://www.paulirish.com/2009/avoiding-the-fouc-v3/).
-
 ### Language Attribute
 
 Please consider specifying the language of your content by adding a
@@ -25,7 +18,7 @@ Please consider specifying the language of your content by adding a
 to the `lang` attribute in the `<html>` as in this example:
 
 ```html
-<html class="no-js" lang="en">
+<html lang="en">
 ```
 
 ### The order of the `<title>` and `<meta>` tags

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="">
+<html lang="">
 
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
Currently a `no-js` class is added to the `<html>` element, which is immediately replaced with a `js` class to allow targeting styles to whether JavaScript is or isn't enabled. This works well however has a few drawbacks:

1. It is mostly incompatible with server-side-rendered frameworks. For example, using a React-based SSR framework causes warnings due to a props mismatch on hydration, so the only safe way to perform the class swapping would be waiting until hydration has completed leading to FOUT.

2. Requires coordination of HTML and CSS so could not reliably be part of e.g. a CSS-only library or a WordPress plugin without control of the site's theme.

3. Requires managing an inline script which on its own is additional complexity and also complicates configuring a JavaScript content security policy.

Things have progressed since the class-based approach was developed, and there is now a [`scripting` media condition](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting) available to achieve the same thing without needing any HTML nor JS.

The `scripting` media condition reached Baseline 2023 support so it is a little on the edge of broad support, however considering the drawbacks of the current approach and the entire principle of progressive enhancement that adjusting styles based on JS availability is built on I think it can begin to be adopted in new projects and H5BP can start directing developers towards adopting it as a new best practice compared to the previous class-based approach.

I've added a mention of the new approach to the documentation including examples & references. If this proposal is accepted I can also open a PR in H5BP's `main.css` project to add an example like [the existing responsive media queries](https://github.com/h5bp/main.css/blob/main/src/_mqs.css) if the maintainers are interested.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/h5bp/html5-boilerplate/blob/main/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.