### PR TITLE
Add groups and limit for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,39 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     versioning-strategy: increase
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  
   - package-ecosystem: npm
     directory: "/src/"
     schedule:
-      interval: weekly
+      interval: monthly
     versioning-strategy: increase
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
This pull request updates the Dependabot configuration to better manage automated dependency updates for GitHub Actions. The main changes group all GitHub Actions updates together and limit the number of open Dependabot pull requests.

Dependabot configuration improvements:

* Added a `groups` section under the GitHub Actions update configuration to group all actions updates into a single pull request using the `github-actions` group.
* Set `open-pull-requests-limit` to 2 to restrict the number of simultaneous open Dependabot PRs for GitHub Actions.

FYI: @roblarsen - I closed the open GH Action update PRs to cut down on Git noise... once this is merged Dependabot should auto-create 1 combined PR each month which will be quicker/easier.