### PR TITLE
Document color-scheme meta extension

### DIFF
--- a/docs/extend.md
+++ b/docs/extend.md
@@ -334,6 +334,21 @@ for an iPhone:
 <link rel="apple-touch-startup-image" media="(max-device-width: 480px) and (-webkit-min-device-pixel-ratio: 2)" href="img/startup.png">
 ```
 
+### Color Scheme
+
+You can add the [`color-scheme` meta
+extension](https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme)
+in the `<head>` of your pages to indicate which color schemes the page supports.
+Browsers can use this information for built-in UI, such as form controls,
+scrollbars, and the default canvas color.
+
+```html
+<meta name="color-scheme" content="light dark">
+```
+
+Only list color schemes that your page actually supports. The first value is the
+preferred scheme.
+
 ### Theme Color
 
 You can add the [`theme-color` meta

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -347,7 +347,7 @@ scrollbars, and the default canvas color.
 ```
 
 Only list color schemes that your page actually supports. The first value is the
-preferred scheme.
+preferred scheme for user agent UI.
 
 ### Theme Color
 


### PR DESCRIPTION
Fixes #3031

## Summary
- Add documentation for the `color-scheme` meta extension.
- Note that browsers may use it for built-in UI and that pages should only list schemes they support.

## Verification
- `npx --yes prettier@3.6.2 --check docs/extend.md`
- `git diff --check`