### PR TITLE
Update NodeJS Support

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,10 +1,11 @@
 name: Scorecard supply-chain security
+
 on:
   branch_protection_rule:
   schedule:
-    - cron: '27 12 * * 2'
+    - cron: "27 12 * * 2"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions: read-all
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         node-version:
           - 22
           - 24
+          - 26
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,10 @@
         "gulp-rename": "^2.1.0",
         "main.css": "3.0.0",
         "mocha": "^11.7.5",
-        "prettier": "3.6.2"
+        "prettier": "3.8.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1979,9 +1979,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3605,10 +3605,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -43,17 +43,17 @@
     "gulp-rename": "^2.1.0",
     "main.css": "3.0.0",
     "mocha": "^11.7.5",
-    "prettier": "3.6.2"
+    "prettier": "3.8.4"
   },
   "overrides": {
     "diff": "^8.0.3",
     "serialize-javascript": "^7.0.5"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "volta": {
-    "node": "20.19.1"
+    "node": "22.23.1"
   },
   "h5bp-configs": {
     "directories": {


### PR DESCRIPTION
Fixes: #3440

- Minimum = Node v22
- Add Node v26 to support (as its current https://nodejs.org/en/about/previous-releases)
- I ran `npm audit fix` too which updated brace-expansion

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/h5bp/html5-boilerplate/blob/main/.github/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
